### PR TITLE
fix(captions): normalize subtitleLocaleCodes to prevent object metadata in file paths

### DIFF
--- a/src/api/renderJobConfig.js
+++ b/src/api/renderJobConfig.js
@@ -48,12 +48,30 @@ function normalizeCaptionsConfig(raw = {}) {
 
 function normalizeLocalizationConfig(raw = {}) {
   if (!raw || typeof raw !== "object") return {};
+
+  // Resolve subtitle locale codes from the most specific source available.
+  // IMPORTANT: Do NOT fall back to raw.locales — that field may contain rich
+  // metadata objects (e.g. { tone: "..." }) which are not valid locale codes
+  // and would produce paths like "game-[object Object].srt".
+  const rawCodes =
+    raw.subtitleLocaleCodes || raw.subtitle_locale_codes ||
+    raw.rules?.subtitleNaming?.locales || {};
+
+  // Defensive: ensure every value is a string so object metadata never leaks
+  // into file-path construction.
+  const subtitleLocaleCodes = {};
+  for (const [key, value] of Object.entries(rawCodes)) {
+    if (typeof value === "string") {
+      subtitleLocaleCodes[key] = value;
+    }
+  }
+
   return {
     defaultLocale: raw.defaultLocale || raw.default_locale,
     subtitleNamingPattern:
-      raw.subtitleNamingPattern || raw.subtitle_naming_pattern || "{game}-{locale}.srt",
-    subtitleLocaleCodes:
-      raw.subtitleLocaleCodes || raw.subtitle_locale_codes || raw.locales || {},
+      raw.subtitleNamingPattern || raw.subtitle_naming_pattern ||
+      raw.rules?.subtitleNaming?.pattern || "{game}-{locale}.srt",
+    subtitleLocaleCodes,
     locales: raw.locales || {},
   };
 }

--- a/tests/api/render_job_config_captions.test.js
+++ b/tests/api/render_job_config_captions.test.js
@@ -93,4 +93,50 @@ describe('buildRenderJobConfig captions', () => {
     expect(config.assets.captions[0].locale).toBe('en-US');
     expect(config.options.burnInCaptions).toBe(false);
   });
+
+  it('resolves locale codes from rules.subtitleNaming when top-level locales are metadata objects', () => {
+    // Simulate the real config/localization.json shape where locales contains
+    // rich metadata objects and the actual string codes live under rules.
+    const metadataLocalizationConfig = {
+      defaultLocale: 'en-US',
+      locales: {
+        'en-US': { tone: 'warm, beginner-friendly' },
+        'fr-FR': { tone: 'formal-neutral' },
+      },
+      rules: {
+        subtitleNaming: {
+          pattern: '{game}-{locale}.srt',
+          locales: { 'en-US': 'en', 'fr-FR': 'fr' },
+        },
+      },
+    };
+
+    fs.writeFileSync(LOCALIZATION_GENERATED_PATH, JSON.stringify(metadataLocalizationConfig));
+
+    const config = buildRenderJobConfig({
+      projectId: 'p-metadata-fallback',
+      ingestionManifest,
+      storyboardManifest,
+      lang: 'en',
+      captionLocales: ['en-US', 'fr-FR'],
+      burnInCaptions: true,
+    });
+
+    expect(config.assets.captions).toHaveLength(2);
+    expect(config.assets.captions[0]).toMatchObject({
+      languageCode: 'en',
+      locale: 'en-US',
+      path: 'demo-game-en.srt',
+    });
+    expect(config.assets.captions[1]).toMatchObject({
+      languageCode: 'fr',
+      locale: 'fr-FR',
+      path: 'demo-game-fr.srt',
+    });
+    // Ensure no [object Object] leaked into any path
+    config.assets.captions.forEach((track) => {
+      expect(track.path).not.toContain('[object Object]');
+      expect(typeof track.languageCode).toBe('string');
+    });
+  });
 });


### PR DESCRIPTION
## Caption locale-code normalization fix

### Problem

`normalizeLocalizationConfig` fell back to `raw.locales` for subtitle locale codes, but `config/localization.json` now stores rich metadata objects at that path (e.g. `{ tone: "warm, beginner-friendly" }`). This caused `languageCode` to become an object and caption file paths to render as `demo-game-[object Object].srt`.

### Fix

- Changed the fallback chain in `normalizeLocalizationConfig` to prefer `raw.rules?.subtitleNaming?.locales` (which contains the actual string codes) instead of `raw.locales`.
- Added a defensive filter that strips any non-string values from the resolved `subtitleLocaleCodes` map, preventing future regressions.
- Removed the `raw.locales` fallback from the subtitle code resolution entirely — that field is preserved separately as `locales` for its actual metadata purpose.

### Scope

This PR contains only the caption normalization fix:
- `src/api/renderJobConfig.js` — `normalizeLocalizationConfig` fix
- `tests/api/render_job_config_captions.test.js` — existing tests pass + new coverage for the metadata-object fallback scenario

No Jest/ESM/CI infrastructure changes. Stacked on PR #389 which provides the working test baseline.

### Validation

- `render_job_config_captions.test.js`: 3/3 pass (including new fallback test)
- `render_job_config.test.js`: 5/5 pass (no regression)
