### PR TITLE
fix(ci): resolve remaining branch-protection blockers (client no-tests + E2E sha256)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: .
 
       - name: Unit tests (client)
-        run: npm test -- --ci --reporters=default
+        run: npm test -- --ci --reporters=default --passWithNoTests
         working-directory: client
         continue-on-error: false
 

--- a/scripts/run_mobius_e2e.cjs
+++ b/scripts/run_mobius_e2e.cjs
@@ -11,6 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const { runIngestionPipeline } = require('../src/ingestion/pipeline');
 const { generateStoryboardFromIngestion } = require('../src/storyboard/storyboard_from_ingestion');
 
@@ -34,6 +35,11 @@ function parseArgs(argv) {
 
 function ensureDir(targetPath) {
   fs.mkdirSync(targetPath, { recursive: true });
+}
+
+function sha256File(filePath) {
+  const content = fs.readFileSync(filePath);
+  return crypto.createHash('sha256').update(content).digest('hex');
 }
 
 function loadJson(filePath) {
@@ -114,6 +120,7 @@ function writePlaceholderArtifacts(outputDir, { lang, resolution, timing }) {
         duration: referenceDuration,
         resolution: resolution?.width && resolution?.height ? { width: resolution.width, height: resolution.height } : undefined,
         format: 'mp4',
+        sha256: sha256File(videoPath),
       },
     ],
     captions: [
@@ -122,6 +129,7 @@ function writePlaceholderArtifacts(outputDir, { lang, resolution, timing }) {
         path: captionName,
         language: lang || 'en',
         format: 'vtt',
+        sha256: sha256File(captionPath),
       },
     ],
     manifest: {


### PR DESCRIPTION
## fix(ci): resolve remaining branch-protection blockers

### Problem

Two pre-existing CI failures block branch protection for PRs #389 and #390:

1. `build-and-qa` / `Unit tests (client)`: The `client/` directory has zero test files. `react-scripts test --ci` exits with code 1 when no tests are found, failing the step on all 3 OS matrices.

2. `MOBIUS E2E Orchestrator` / `I03`: Placeholder media artifacts generated by the E2E orchestrator lacked `sha256` hashes, causing checklist rule I03 to fail with "Missing sha256 on one or more media entries".

### Fix

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added `--passWithNoTests` to the client test step in `build-and-qa` |
| `scripts/run_mobius_e2e.cjs` | Added `sha256` hash generation for placeholder video and caption artifacts |

### Validation

- `tests/utils/checklist_validator.test.js`: 3/3 pass
- `tests/utils/mobius_e2e_orchestrator.test.js`: 2/2 pass
- Direct E2E run (`node scripts/run_mobius_e2e.cjs --game hanamikoji ...`): `E2E PASS`

### Scope

This PR fixes only the two branch-protection blockers. It does not touch:
- Elite ESM split (PR #389)
- Caption normalization (PR #390)
- Any test logic, scoring, or contract behavior
