### PR TITLE
fix(ci): correct EBUR128 true-peak token matching in audio gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
             echo "Integrated loudness result was not found in EBUR128 output." >&2
             exit 1
           fi
-          if ! grep -q 'TP:' artifacts/preview_with_audio_ebur128.txt; then
+          if ! grep -q 'True peak' artifacts/preview_with_audio_ebur128.txt; then
             echo "True-peak result was not found in EBUR128 output." >&2
             exit 1
           fi
@@ -152,7 +152,7 @@ jobs:
           if (-not (Select-String -Path 'artifacts/preview_with_audio_ebur128.txt' -Pattern 'I:')) {
             Write-Error 'Integrated loudness result was not found in EBUR128 output.'
           }
-          if (-not (Select-String -Path 'artifacts/preview_with_audio_ebur128.txt' -Pattern 'TP:')) {
+          if (-not (Select-String -Path 'artifacts/preview_with_audio_ebur128.txt' -Pattern 'True peak')) {
             Write-Error 'True-peak result was not found in EBUR128 output.'
           }
         shell: pwsh
@@ -169,7 +169,7 @@ jobs:
           log_text = pathlib.Path('artifacts/preview_with_audio_ebur128.txt').read_text(encoding='utf-8')
 
           integrated = re.search(r'I:\s*(-?\d+(?:\.\d+)?)', log_text)
-          true_peak = re.search(r'TP:\s*(-?\d+(?:\.\d+)?)', log_text)
+          true_peak = re.search(r'Peak:\s*(-?\d+(?:\.\d+)?)', log_text)
 
           if integrated and true_peak:
               payload = {
@@ -185,7 +185,7 @@ jobs:
         run: |
           $logText = Get-Content 'artifacts/preview_with_audio_ebur128.txt' -Raw
           $integratedMatch = [regex]::Match($logText, 'I:\s*(-?\d+(?:\.\d+)?)')
-          $truePeakMatch = [regex]::Match($logText, 'TP:\s*(-?\d+(?:\.\d+)?)')
+          $truePeakMatch = [regex]::Match($logText, 'Peak:\s*(-?\d+(?:\.\d+)?)')
           if ($integratedMatch.Success -and $truePeakMatch.Success) {
             $payload = [ordered]@{
               integrated_lufs = [double]$integratedMatch.Groups[1].Value


### PR DESCRIPTION
## Summary

Fixes the audio gates and EBUR128 metrics extraction steps that grep/regex for \TP:\ to validate true-peak presence. FFmpeg's \bur128\ filter (with \peak=true\) outputs the section as \True peak:\ with the value on a \Peak:\ line — there is no \TP:\ token in the output.

## Changes (ci.yml only, 4 lines)

- Audio gates (Unix): \grep 'TP:'\ → \grep 'True peak'\
- Audio gates (Windows): \Select-String 'TP:'\ → \Select-String 'True peak'\
- Extract EBUR128 metrics (Unix): regex \TP:\ → \Peak:\ for value capture
- Extract EBUR128 metrics (Windows): regex \TP:\ → \Peak:\ for value capture

## Context

PR #392 fixed the missing \scripts/render-ffmpeg.mjs\, allowing \uild-and-qa\ to advance past the Render preview step. This exposed the next downstream blocker: audio gates fail on all three OSes because the \TP:\ token doesn't exist in ffmpeg's EBUR128 output format.

## Stack

- PR #389 → \main\ (Elite ESM split)
- PR #391 → PR #389 (client no-tests + E2E sha256)
- PR #392 → PR #391 (render preview missing script)
- **This PR** → PR #392 (audio gates true-peak detection)
- PR #390 → PR #389 (caption locale normalization)

Merge order: #389 → #391 → #392 → this → #390