### PR TITLE
feat: wire storyboard renderer as default backend render entrypoint

### DIFF
--- a/src/api/renderExecutor.js
+++ b/src/api/renderExecutor.js
@@ -7,6 +7,13 @@ const moduleDirname = path.join(process.cwd(), 'src', 'api');
 export const RENDER_OUTPUT_BASE =
   process.env.JOB_RESULTS_DIR || path.join(moduleDirname, 'uploads', 'render-jobs');
 
+/** Default storyboard renderer script (relative to project root). */
+export const DEFAULT_STORYBOARD_RENDERER = path.join(
+  process.cwd(),
+  'scripts',
+  'render-storyboard-ffmpeg.mjs',
+);
+
 function parseProgress(line) {
   const match = line.match(/progress[:=]\s*(\d{1,3})/i);
   if (!match) return null;
@@ -25,12 +32,65 @@ async function writeConfig(jobOutputDir, jobId, config) {
   return configPath;
 }
 
-function buildCommand({ jobId, configPath, jobOutputDir }) {
+/**
+ * Adapt the internal render job config (from buildRenderJobConfig) into the
+ * scene-based format expected by render-storyboard-ffmpeg.mjs.
+ */
+export function adaptConfigForStoryboardRenderer(jobConfig, { outputPath } = {}) {
+  const video = jobConfig.video || {};
+  const resolution = video.resolution || { width: 1920, height: 1080 };
+  const fps = video.fps || 30;
+  const projectId = jobConfig.projectId || 'unknown';
+
+  // Build scenes from storyboard data or timing data
+  const storyboardScenes = jobConfig.assets?.storyboardScenes || [];
+  const timingScenes = jobConfig.timing?.scenes || [];
+  const sourceScenes = storyboardScenes.length > 0 ? storyboardScenes : timingScenes;
+
+  const scenes = sourceScenes.map((scene, idx) => ({
+    id: scene.id || `scene-${idx + 1}`,
+    durationSec: scene.durationSec || 3,
+    background: scene.background || { color: idx === 0 ? '#1a1a2e' : '#16213e' },
+    overlays: scene.overlays || [
+      { type: 'title', text: scene.id || `Scene ${idx + 1}`, position: 'center' },
+    ],
+    audio: scene.audio || undefined,
+  }));
+
+  // If no scenes available, create a single placeholder scene
+  if (scenes.length === 0) {
+    const totalDuration = jobConfig.timing?.totalDurationSec || 6;
+    scenes.push({
+      id: 'scene-placeholder',
+      durationSec: totalDuration,
+      background: { color: '#1a1a2e' },
+      overlays: [
+        { type: 'title', text: jobConfig.gameName || projectId, position: 'center' },
+        { type: 'body', text: 'Tutorial Preview', position: 'bottom' },
+      ],
+    });
+  }
+
+  return {
+    projectId,
+    video: { resolution, fps },
+    scenes,
+    _outputPath: outputPath || undefined,
+    _source: 'renderExecutor-adapter',
+  };
+}
+
+export function buildCommand({ jobId, configPath, jobOutputDir, outputFilePath }) {
   const rendererCommand = process.env.RENDERER_COMMAND;
   const rendererArgsEnv = process.env.RENDERER_ARGS || '';
   const rendererEntrypoint = process.env.RENDERER_ENTRYPOINT;
+  const dryRun = process.env.RENDERER_DRY_RUN === 'true';
 
-  if (!rendererCommand && !rendererEntrypoint) {
+  // Priority: RENDERER_COMMAND > RENDERER_ENTRYPOINT > default storyboard renderer
+  const useStoryboardDefault = !rendererCommand && !rendererEntrypoint;
+  const entrypoint = rendererEntrypoint || (useStoryboardDefault ? DEFAULT_STORYBOARD_RENDERER : null);
+
+  if (!rendererCommand && !entrypoint) {
     throw new Error('RENDERER_COMMAND_NOT_CONFIGURED');
   }
 
@@ -39,15 +99,29 @@ function buildCommand({ jobId, configPath, jobOutputDir }) {
     .map((arg) => arg.trim())
     .filter(Boolean);
 
-  if (rendererEntrypoint) {
-    args.push(rendererEntrypoint);
+  if (entrypoint) {
+    args.push(entrypoint);
   }
 
-  args.push('--job-id', jobId, '--config', configPath, '--output', jobOutputDir);
+  if (useStoryboardDefault) {
+    // Use storyboard renderer CLI interface
+    args.push('--config', configPath);
+    if (outputFilePath) {
+      args.push('--out', outputFilePath);
+    }
+    if (dryRun) {
+      args.push('--dry-run');
+    }
+  } else {
+    // Legacy renderer interface
+    args.push('--job-id', jobId, '--config', configPath, '--output', jobOutputDir);
+  }
 
   return {
     command: rendererCommand || 'node',
     args,
+    entrypoint: entrypoint || rendererCommand,
+    isStoryboardRenderer: useStoryboardDefault,
   };
 }
 
@@ -61,8 +135,25 @@ export async function runRenderJob(job, options = {}) {
   const publicBasePath = path.join('/uploads/render-jobs', job.id);
   await ensureDir(jobOutputDir);
 
-  const configPath = await writeConfig(jobOutputDir, job.id, job.config);
-  const { command, args } = buildCommand({ jobId: job.id, configPath, jobOutputDir });
+  // Determine if we should adapt config for storyboard renderer
+  const useStoryboard = !process.env.RENDERER_COMMAND && !process.env.RENDERER_ENTRYPOINT;
+  const outputFilePath = useStoryboard
+    ? path.join(jobOutputDir, `${job.id}-preview.mp4`)
+    : null;
+
+  // Write the renderer-appropriate config
+  let configToWrite = job.config;
+  if (useStoryboard) {
+    configToWrite = adaptConfigForStoryboardRenderer(job.config, { outputPath: outputFilePath });
+  }
+
+  const configPath = await writeConfig(jobOutputDir, job.id, configToWrite);
+  const { command, args, entrypoint, isStoryboardRenderer } = buildCommand({
+    jobId: job.id,
+    configPath,
+    jobOutputDir,
+    outputFilePath,
+  });
 
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -122,6 +213,10 @@ export async function runRenderJob(job, options = {}) {
             manifestPath,
             zipPath,
             packagingError: packagingResult.packagingError,
+            rendererEntrypoint: entrypoint,
+            isStoryboardRenderer,
+            configPath,
+            outputFilePath,
           });
         } catch (err) {
           reject(err);
@@ -130,6 +225,8 @@ export async function runRenderJob(job, options = {}) {
         const error = new Error(
           `Render process exited with code ${code}: ${stderrLines.join('\n').trim()}`,
         );
+        error.rendererEntrypoint = entrypoint;
+        error.configPath = configPath;
         reject(error);
       }
     });

--- a/tests/render/render_executor_storyboard.test.js
+++ b/tests/render/render_executor_storyboard.test.js
@@ -1,0 +1,172 @@
+/**
+ * Tests for renderExecutor.js storyboard renderer wiring.
+ * Verifies that the executor defaults to the real storyboard renderer
+ * and correctly adapts configs.
+ */
+
+const path = require('path');
+
+// We need to use dynamic import for the ESM module
+let buildCommand, adaptConfigForStoryboardRenderer, DEFAULT_STORYBOARD_RENDERER;
+
+beforeAll(async () => {
+  const mod = await import('../../src/api/renderExecutor.js');
+  buildCommand = mod.buildCommand;
+  adaptConfigForStoryboardRenderer = mod.adaptConfigForStoryboardRenderer;
+  DEFAULT_STORYBOARD_RENDERER = mod.DEFAULT_STORYBOARD_RENDERER;
+});
+
+describe('renderExecutor storyboard wiring', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore env
+    delete process.env.RENDERER_COMMAND;
+    delete process.env.RENDERER_ENTRYPOINT;
+    delete process.env.RENDERER_ARGS;
+    delete process.env.RENDERER_DRY_RUN;
+  });
+
+  describe('buildCommand', () => {
+    test('defaults to storyboard renderer when no RENDERER_COMMAND or RENDERER_ENTRYPOINT', () => {
+      delete process.env.RENDERER_COMMAND;
+      delete process.env.RENDERER_ENTRYPOINT;
+
+      const result = buildCommand({
+        jobId: 'test-job',
+        configPath: '/tmp/config.json',
+        jobOutputDir: '/tmp/output',
+        outputFilePath: '/tmp/output/preview.mp4',
+      });
+
+      expect(result.command).toBe('node');
+      expect(result.isStoryboardRenderer).toBe(true);
+      expect(result.args).toContain(DEFAULT_STORYBOARD_RENDERER);
+      expect(result.args).toContain('--config');
+      expect(result.args).toContain('/tmp/config.json');
+      expect(result.args).toContain('--out');
+      expect(result.args).toContain('/tmp/output/preview.mp4');
+    });
+
+    test('uses RENDERER_ENTRYPOINT when set', () => {
+      process.env.RENDERER_ENTRYPOINT = '/custom/renderer.js';
+
+      const result = buildCommand({
+        jobId: 'test-job',
+        configPath: '/tmp/config.json',
+        jobOutputDir: '/tmp/output',
+      });
+
+      expect(result.command).toBe('node');
+      expect(result.isStoryboardRenderer).toBe(false);
+      expect(result.args).toContain('/custom/renderer.js');
+      expect(result.args).toContain('--job-id');
+    });
+
+    test('uses RENDERER_COMMAND when set', () => {
+      process.env.RENDERER_COMMAND = 'python3';
+      process.env.RENDERER_ENTRYPOINT = '/custom/render.py';
+
+      const result = buildCommand({
+        jobId: 'test-job',
+        configPath: '/tmp/config.json',
+        jobOutputDir: '/tmp/output',
+      });
+
+      expect(result.command).toBe('python3');
+      expect(result.isStoryboardRenderer).toBe(false);
+      expect(result.args).toContain('/custom/render.py');
+    });
+
+    test('includes --dry-run when RENDERER_DRY_RUN is true', () => {
+      delete process.env.RENDERER_COMMAND;
+      delete process.env.RENDERER_ENTRYPOINT;
+      process.env.RENDERER_DRY_RUN = 'true';
+
+      const result = buildCommand({
+        jobId: 'test-job',
+        configPath: '/tmp/config.json',
+        jobOutputDir: '/tmp/output',
+      });
+
+      expect(result.args).toContain('--dry-run');
+    });
+  });
+
+  describe('adaptConfigForStoryboardRenderer', () => {
+    test('adapts a render job config with storyboard scenes', () => {
+      const jobConfig = {
+        projectId: 'hanamikoji',
+        video: { resolution: { width: 1920, height: 1080 }, fps: 30 },
+        assets: {
+          storyboardScenes: [
+            { id: 'scene-intro', durationSec: 5, type: 'intro' },
+            { id: 'scene-setup-1', durationSec: 8, type: 'setup_step' },
+          ],
+        },
+        timing: { totalDurationSec: 13, scenes: [] },
+      };
+
+      const adapted = adaptConfigForStoryboardRenderer(jobConfig);
+
+      expect(adapted.projectId).toBe('hanamikoji');
+      expect(adapted.video.resolution.width).toBe(1920);
+      expect(adapted.video.fps).toBe(30);
+      expect(adapted.scenes).toHaveLength(2);
+      expect(adapted.scenes[0].id).toBe('scene-intro');
+      expect(adapted.scenes[0].durationSec).toBe(5);
+      expect(adapted.scenes[1].id).toBe('scene-setup-1');
+    });
+
+    test('falls back to timing scenes when storyboard scenes are empty', () => {
+      const jobConfig = {
+        projectId: 'test',
+        video: { resolution: { width: 1280, height: 720 }, fps: 30 },
+        assets: { storyboardScenes: [] },
+        timing: {
+          totalDurationSec: 10,
+          scenes: [
+            { id: 'scene-1', durationSec: 4 },
+            { id: 'scene-2', durationSec: 6 },
+          ],
+        },
+      };
+
+      const adapted = adaptConfigForStoryboardRenderer(jobConfig);
+
+      expect(adapted.scenes).toHaveLength(2);
+      expect(adapted.scenes[0].id).toBe('scene-1');
+      expect(adapted.scenes[1].id).toBe('scene-2');
+    });
+
+    test('creates placeholder scene when no scenes are available', () => {
+      const jobConfig = {
+        projectId: 'empty-game',
+        gameName: 'Test Game',
+        video: { resolution: { width: 1920, height: 1080 }, fps: 30 },
+        timing: { totalDurationSec: 6, scenes: [] },
+      };
+
+      const adapted = adaptConfigForStoryboardRenderer(jobConfig);
+
+      expect(adapted.scenes).toHaveLength(1);
+      expect(adapted.scenes[0].id).toBe('scene-placeholder');
+      expect(adapted.scenes[0].durationSec).toBe(6);
+      expect(adapted.scenes[0].overlays[0].text).toBe('Test Game');
+    });
+
+    test('preserves output path when provided', () => {
+      const jobConfig = {
+        projectId: 'test',
+        video: { resolution: { width: 1280, height: 720 }, fps: 30 },
+        timing: { totalDurationSec: 5, scenes: [{ id: 's1', durationSec: 5 }] },
+      };
+
+      const adapted = adaptConfigForStoryboardRenderer(jobConfig, {
+        outputPath: '/out/preview.mp4',
+      });
+
+      expect(adapted._outputPath).toBe('/out/preview.mp4');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Wires \scripts/render-storyboard-ffmpeg.mjs\ (from PR #395) as the default backend render entrypoint. The backend no longer throws \RENDERER_COMMAND_NOT_CONFIGURED\ — it now has a functional render path.

### Changes

**\src/api/renderExecutor.js\:**
- \uildCommand()\ defaults to the storyboard renderer when no \RENDERER_COMMAND\ / \RENDERER_ENTRYPOINT\ env vars are set
- New \daptConfigForStoryboardRenderer()\ transforms internal render job config into the renderer's scene-based format
- \unRenderJob()\ auto-detects storyboard mode and passes \--config\ / \--out\ CLI args
- Supports \RENDERER_DRY_RUN=true\ for CI validation without FFmpeg
- Legacy renderer paths remain functional
- Response includes diagnostic metadata (entrypoint used, config path, output path)

**\	ests/render/render_executor_storyboard.test.js\** (8 tests):
- Default entrypoint resolution
- Explicit RENDERER_ENTRYPOINT override
- RENDERER_COMMAND override  
- Dry-run flag inclusion
- Config adaptation: storyboard scenes, timing fallback, placeholder creation, output path

### What this enables

After this + PR #395 merge, calling \POST /api/render\ with a project that has ingestion + storyboard data will invoke the real FFmpeg renderer (or dry-run cleanly without FFmpeg). No more \RENDERER_COMMAND_NOT_CONFIGURED\ errors.

### Stack

- PR #395 → \main\ (renderer foundation + roadmap)
- **This PR** → PR #395 (backend wiring)

### Test results

All 20 suites, 102 tests pass (8 new).