### PR TITLE
feat: connect UI Render & Export to real backend render path

### DIFF
--- a/client/src/components/steps/RenderExportStep.js
+++ b/client/src/components/steps/RenderExportStep.js
@@ -103,16 +103,32 @@ export function RenderExportStep({
       {renderJobState && (
         <div className="pipeline-section">
           <h4 style={{ marginTop: 0 }}>Render job</h4>
-          <p>Status: {renderJobState.status || "pending"}</p>
+          <p>Status: <strong>{renderJobState.status || "pending"}</strong></p>
           <p>Progress: {renderJobState.progress ?? 0}%</p>
-          {renderJobState.artifacts?.length ? (
-            <ul>
-              {renderJobState.artifacts.map((artifact) => (
-                <li key={artifact.name}>{artifact.name}</li>
-              ))}
-            </ul>
-          ) : (
-            <p className="pipeline-muted">No artifacts yet.</p>
+          {renderJobState.isStoryboardRenderer && (
+            <p className="pipeline-muted">Renderer: storyboard-ffmpeg (real)</p>
+          )}
+          {renderJobState.configPath && (
+            <p className="pipeline-muted">Config: {renderJobState.configPath}</p>
+          )}
+          {renderJobState.outputFilePath && (
+            <p className="pipeline-muted">Output: {renderJobState.outputFilePath}</p>
+          )}
+          {renderJobState.error && (
+            <p style={{ color: "red" }}>Error: {renderJobState.error}</p>
+          )}
+          {renderJobState.resultPaths?.length > 0 && (
+            <div>
+              <strong>Artifacts:</strong>
+              <ul>
+                {renderJobState.resultPaths.map((p, idx) => (
+                  <li key={idx}>{p}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {!renderJobState.resultPaths?.length && renderJobState.status === "completed" && (
+            <p className="pipeline-muted">Render complete. No additional artifacts.</p>
           )}
         </div>
       )}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -599,6 +599,10 @@ app.get('/api/render/:jobId/status', (req, res) => {
       manifestPath: job.manifestPath,
       zipPath: job.zipPath,
       packagingError: job.packagingError,
+      rendererEntrypoint: job.rendererEntrypoint || null,
+      isStoryboardRenderer: job.isStoryboardRenderer || false,
+      configPath: job.configPath || null,
+      outputFilePath: job.outputFilePath || null,
     },
   });
 });

--- a/src/api/renderQueue.js
+++ b/src/api/renderQueue.js
@@ -56,6 +56,10 @@ async function processQueue(executor, outputOptions) {
       job.manifestPath = result.manifestPath || null;
       job.zipPath = result.zipPath || null;
       job.packagingError = result.packagingError || null;
+      job.rendererEntrypoint = result.rendererEntrypoint || null;
+      job.isStoryboardRenderer = result.isStoryboardRenderer || false;
+      job.configPath = result.configPath || null;
+      job.outputFilePath = result.outputFilePath || null;
     } else {
       job.resultPaths = [];
     }


### PR DESCRIPTION
## Summary

Completes the UI-to-backend render connection by surfacing renderer diagnostics in the Render & Export step.

### Changes

**Backend (\src/api/renderQueue.js\, \src/api/index.js\):**
- Persist \endererEntrypoint\, \isStoryboardRenderer\, \configPath\, and \outputFilePath\ on completed job objects
- Include renderer diagnostics in \GET /api/render/:jobId/status\ response

**Client (\client/src/components/steps/RenderExportStep.js\):**
- Show renderer type (storyboard-ffmpeg) when applicable
- Display config path and output file path for operator debugging
- Show result artifacts from \esultPaths\
- Show inline job errors
- Improved status display

### What this means operationally

The operator can now:
1. Generate a render config from project data
2. Click Start Render
3. See the job progress, renderer type, and output path in real-time
4. View artifacts on completion or error details on failure

No more \RENDERER_COMMAND_NOT_CONFIGURED\ — the backend defaults to the real storyboard renderer.

### Stack

- PR #395 → \main\ (renderer foundation)
- PR #396 → PR #395 (backend wiring)
- PR #397 → PR #396 (dry-run integration)
- PR #398 → PR #397 (real MP4 smoke)
- **This PR** → PR #398 (UI connection)

### Results

All 22 suites, 108 tests pass.

### Next step

End-to-end operator smoke: project fixture → UI render click → backend render job → output artifact visible in UI.