### PR TITLE
feat: deterministic component-to-scene visual matching

### DIFF
--- a/src/services/imageAssetMatcher.js
+++ b/src/services/imageAssetMatcher.js
@@ -1,0 +1,150 @@
+/**
+ * Deterministic image-to-scene visual matcher.
+ *
+ * Assigns validated image assets to storyboard scenes based on:
+ * 1. Explicit existing imageId/imageRef (preserved, never overwritten)
+ * 2. Component ID exact match
+ * 3. Component name / alias match (normalized)
+ * 4. Image tags matching scene type
+ * 5. Scene type heuristic (intro→box-art, setup→board/overview, etc.)
+ *
+ * Produces confidence scores and reasons for each assignment.
+ * Missing matches get explicit warnings and safe fallback.
+ */
+
+/**
+ * Normalize a string for fuzzy matching (lowercase, strip special chars, collapse whitespace).
+ */
+function normalizeForMatch(str) {
+  if (!str || typeof str !== 'string') return '';
+  return str.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Scene type to preferred image tag mapping.
+ */
+const SCENE_TYPE_TAG_PREFERENCES = {
+  intro: ['box-art', 'cover', 'box', 'title'],
+  setup_step: ['board', 'overview', 'setup', 'components'],
+  component: ['component', 'card', 'token', 'piece', 'tile'],
+  scoring: ['scoring', 'points', 'track'],
+  end_card: ['box-art', 'cover', 'logo'],
+  gameplay: ['gameplay', 'action', 'turn'],
+};
+
+/**
+ * Try to match a scene to an image asset.
+ * Returns { imageId, confidence, reason } or null.
+ */
+function findBestMatch(scene, imageAssets) {
+  if (!imageAssets || imageAssets.length === 0) return null;
+
+  const sceneId = normalizeForMatch(scene.id || '');
+  const sceneSegment = normalizeForMatch(scene.segmentId || '');
+  const sceneType = (scene.type || '').toLowerCase();
+
+  // Strategy 1: Match by component ID in scene segmentId or id
+  for (const img of imageAssets) {
+    const imgId = normalizeForMatch(img.id || '');
+    const imgName = normalizeForMatch(img.name || '');
+
+    if (imgId && (sceneId.includes(imgId) || sceneSegment.includes(imgId))) {
+      return { imageId: img.id, confidence: 0.9, reason: 'component-id-match' };
+    }
+    if (imgName && sceneSegment && sceneSegment.includes(imgName)) {
+      return { imageId: img.id, confidence: 0.85, reason: 'component-name-match' };
+    }
+  }
+
+  // Strategy 2: Match by image tags aligned with scene type
+  const preferredTags = SCENE_TYPE_TAG_PREFERENCES[sceneType] || [];
+  if (preferredTags.length > 0) {
+    for (const img of imageAssets) {
+      const imgTags = (img.tags || []).map((t) => t.toLowerCase());
+      const matchedTag = preferredTags.find((tag) => imgTags.includes(tag));
+      if (matchedTag) {
+        return { imageId: img.id, confidence: 0.7, reason: `tag-match:${matchedTag}` };
+      }
+    }
+  }
+
+  // Strategy 3: Scene type heuristic — intro/end_card prefers first box-art, setup prefers overview
+  if (sceneType === 'intro' || sceneType === 'end_card') {
+    const boxArt = imageAssets.find((img) =>
+      (img.tags || []).some((t) => ['box-art', 'cover', 'box'].includes(t.toLowerCase()))
+    );
+    if (boxArt) {
+      return { imageId: boxArt.id, confidence: 0.6, reason: 'heuristic-intro-box-art' };
+    }
+  }
+
+  if (sceneType === 'setup_step') {
+    const overview = imageAssets.find((img) =>
+      (img.tags || []).some((t) => ['board', 'overview', 'setup'].includes(t.toLowerCase()))
+    );
+    if (overview) {
+      return { imageId: overview.id, confidence: 0.6, reason: 'heuristic-setup-overview' };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Match all storyboard scenes to available image assets.
+ *
+ * @param {Array} scenes - Storyboard scenes (from storyboardManifest.scenes)
+ * @param {Array} imageAssets - Validated renderer-ready image assets (with renderPath)
+ * @returns {{ matchedScenes, warnings }}
+ */
+export function matchScenesToImages(scenes = [], imageAssets = []) {
+  const warnings = [];
+  const usedImageIds = new Set();
+
+  const matchedScenes = scenes.map((scene) => {
+    // Preserve explicit existing assignments
+    if (scene.imageId || scene.imageRef) {
+      return {
+        ...scene,
+        visualMatchConfidence: 1.0,
+        visualMatchReason: 'explicit-assignment',
+        visualWarnings: [],
+      };
+    }
+
+    const match = findBestMatch(scene, imageAssets);
+
+    if (match) {
+      usedImageIds.add(match.imageId);
+      return {
+        ...scene,
+        imageId: match.imageId,
+        visualMatchConfidence: match.confidence,
+        visualMatchReason: match.reason,
+        visualWarnings: [],
+      };
+    }
+
+    // No match found
+    const warning = `Scene '${scene.id}' (type: ${scene.type || 'unknown'}): no suitable image found`;
+    warnings.push(warning);
+
+    return {
+      ...scene,
+      imageId: null,
+      visualMatchConfidence: 0,
+      visualMatchReason: 'no-match',
+      visualWarnings: [warning],
+    };
+  });
+
+  // Summary warnings for unused images
+  const unusedImages = imageAssets.filter((img) => !usedImageIds.has(img.id));
+  if (unusedImages.length > 0 && scenes.length > 0) {
+    warnings.push(`${unusedImages.length} image(s) not matched to any scene: ${unusedImages.map((i) => i.id).join(', ')}`);
+  }
+
+  return { matchedScenes, warnings };
+}
+
+export { normalizeForMatch, findBestMatch, SCENE_TYPE_TAG_PREFERENCES };

--- a/tests/services/imageAssetMatcher.test.js
+++ b/tests/services/imageAssetMatcher.test.js
@@ -1,0 +1,161 @@
+/**
+ * Tests for deterministic image-to-scene visual matcher.
+ */
+
+const path = require('path');
+
+let matchScenesToImages, normalizeForMatch, findBestMatch;
+
+beforeAll(async () => {
+  const mod = await import('../../src/services/imageAssetMatcher.js');
+  matchScenesToImages = mod.matchScenesToImages;
+  normalizeForMatch = mod.normalizeForMatch;
+  findBestMatch = mod.findBestMatch;
+});
+
+const TEST_IMAGE = path.resolve(__dirname, '../fixtures/images/test-bg-100x100.png');
+
+describe('imageAssetMatcher', () => {
+  describe('normalizeForMatch', () => {
+    test('lowercases and strips special characters', () => {
+      expect(normalizeForMatch('Setup-Phase_1!')).toBe('setupphase1');
+    });
+
+    test('collapses whitespace', () => {
+      expect(normalizeForMatch('  hello   world  ')).toBe('hello world');
+    });
+
+    test('handles null/undefined', () => {
+      expect(normalizeForMatch(null)).toBe('');
+      expect(normalizeForMatch(undefined)).toBe('');
+    });
+  });
+
+  describe('matchScenesToImages', () => {
+    test('preserves explicit scene imageId without overwriting', () => {
+      const scenes = [
+        { id: 'scene-1', type: 'intro', imageId: 'explicit-img' },
+      ];
+      const images = [
+        { id: 'other-img', tags: ['box-art'], renderPath: TEST_IMAGE },
+      ];
+
+      const { matchedScenes } = matchScenesToImages(scenes, images);
+      expect(matchedScenes[0].imageId).toBe('explicit-img');
+      expect(matchedScenes[0].visualMatchConfidence).toBe(1.0);
+      expect(matchedScenes[0].visualMatchReason).toBe('explicit-assignment');
+    });
+
+    test('preserves explicit scene imageRef without overwriting', () => {
+      const scenes = [
+        { id: 'scene-1', type: 'intro', imageRef: 'manual-ref' },
+      ];
+      const images = [
+        { id: 'box-img', tags: ['box-art'], renderPath: TEST_IMAGE },
+      ];
+
+      const { matchedScenes } = matchScenesToImages(scenes, images);
+      expect(matchedScenes[0].imageRef).toBe('manual-ref');
+      expect(matchedScenes[0].visualMatchConfidence).toBe(1.0);
+    });
+
+    test('matches by component ID in scene segmentId', () => {
+      const scenes = [
+        { id: 'scene-setup-cards', segmentId: 'cards', type: 'setup_step' },
+      ];
+      const images = [
+        { id: 'cards', name: 'Cards', tags: ['component'], renderPath: TEST_IMAGE },
+        { id: 'board', name: 'Board', tags: ['board'], renderPath: TEST_IMAGE },
+      ];
+
+      const { matchedScenes } = matchScenesToImages(scenes, images);
+      expect(matchedScenes[0].imageId).toBe('cards');
+      expect(matchedScenes[0].visualMatchReason).toBe('component-id-match');
+      expect(matchedScenes[0].visualMatchConfidence).toBeGreaterThan(0.8);
+    });
+
+    test('matches by image tag aligned with scene type', () => {
+      const scenes = [
+        { id: 'scene-intro', type: 'intro' },
+      ];
+      const images = [
+        { id: 'bg-1', tags: ['box-art'], renderPath: TEST_IMAGE },
+        { id: 'bg-2', tags: ['component'], renderPath: TEST_IMAGE },
+      ];
+
+      const { matchedScenes } = matchScenesToImages(scenes, images);
+      expect(matchedScenes[0].imageId).toBe('bg-1');
+      expect(matchedScenes[0].visualMatchReason).toBe('tag-match:box-art');
+    });
+
+    test('setup scene selects board/overview image', () => {
+      const scenes = [
+        { id: 'scene-setup', type: 'setup_step' },
+      ];
+      const images = [
+        { id: 'img-board', tags: ['board'], renderPath: TEST_IMAGE },
+        { id: 'img-card', tags: ['card'], renderPath: TEST_IMAGE },
+      ];
+
+      const { matchedScenes } = matchScenesToImages(scenes, images);
+      expect(matchedScenes[0].imageId).toBe('img-board');
+    });
+
+    test('produces warning when no suitable image found', () => {
+      const scenes = [
+        { id: 'scene-obscure', type: 'gameplay' },
+      ];
+      const images = [];
+
+      const { matchedScenes, warnings } = matchScenesToImages(scenes, images);
+      expect(matchedScenes[0].imageId).toBeNull();
+      expect(matchedScenes[0].visualMatchConfidence).toBe(0);
+      expect(matchedScenes[0].visualMatchReason).toBe('no-match');
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings[0]).toContain('scene-obscure');
+    });
+
+    test('reports unused images', () => {
+      const scenes = [
+        { id: 'scene-intro', type: 'intro' },
+      ];
+      const images = [
+        { id: 'img-box', tags: ['box-art'], renderPath: TEST_IMAGE },
+        { id: 'img-unused', tags: ['misc'], renderPath: TEST_IMAGE },
+      ];
+
+      const { warnings } = matchScenesToImages(scenes, images);
+      const unusedWarning = warnings.find((w) => w.includes('not matched'));
+      expect(unusedWarning).toBeTruthy();
+      expect(unusedWarning).toContain('img-unused');
+    });
+
+    test('handles empty scenes array', () => {
+      const { matchedScenes, warnings } = matchScenesToImages([], [{ id: 'img-1', renderPath: TEST_IMAGE }]);
+      expect(matchedScenes).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('handles empty images array', () => {
+      const scenes = [{ id: 's1', type: 'intro' }];
+      const { matchedScenes, warnings } = matchScenesToImages(scenes, []);
+      expect(matchedScenes[0].imageId).toBeNull();
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    test('multiple scenes can match different images', () => {
+      const scenes = [
+        { id: 'scene-intro', type: 'intro' },
+        { id: 'scene-setup-tokens', segmentId: 'tokens', type: 'setup_step' },
+      ];
+      const images = [
+        { id: 'box', tags: ['box-art'], renderPath: TEST_IMAGE },
+        { id: 'tokens', tags: ['component'], renderPath: TEST_IMAGE },
+      ];
+
+      const { matchedScenes } = matchScenesToImages(scenes, images);
+      expect(matchedScenes[0].imageId).toBe('box');
+      expect(matchedScenes[1].imageId).toBe('tokens');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds deterministic image-to-scene matching so storyboard scenes automatically receive the most appropriate validated image asset as their background.

### New module: \src/services/imageAssetMatcher.js\

\matchScenesToImages(scenes, imageAssets)\ assigns images to scenes using:

1. **Preserve explicit** — existing \imageId\/\imageRef\ never overwritten (confidence: 1.0)
2. **Component ID match** — scene segmentId matches image ID (confidence: 0.9)
3. **Component name match** — normalized name in scene segment (confidence: 0.85)
4. **Tag alignment** — image tags match scene type preferences (confidence: 0.7)
5. **Type heuristic** — intro→box-art, setup→board/overview (confidence: 0.6)
6. **No match** — explicit warning, null imageId, safe fallback (confidence: 0)

Each matched scene gets: \imageId\, \isualMatchConfidence\, \isualMatchReason\, \isualWarnings\

### Tests (13 new)

- Explicit preservation (imageId and imageRef)
- Component ID/name matching
- Tag-based scene type matching
- Setup/intro heuristics
- Missing match warnings
- Unused image reporting
- Edge cases (empty inputs, multiple scenes)

### Stack

- PRs #395–#401 (render infrastructure + image normalization)
- **This PR** → PR #401 (scene-to-image matching)

All 26 suites, 142 tests pass.

### Next step

Storyboard visual coverage validation — ensure every tutorial segment has a matched image, intentional fallback, or operator warning.