### PR TITLE
feat: storyboard visual coverage validation gate

### DIFF
--- a/src/services/storyboardVisualCoverage.js
+++ b/src/services/storyboardVisualCoverage.js
@@ -1,0 +1,165 @@
+/**
+ * Storyboard visual coverage validator.
+ *
+ * Classifies each scene's visual readiness and produces operator diagnostics
+ * before render begins. Prevents silent rendering of professional tutorial
+ * scenes with missing visuals.
+ *
+ * Coverage classes:
+ * - covered: scene has a matched/explicit validated image (confidence >= threshold)
+ * - intentionalFallback: scene type allows color/text-only (intro, end_card, transition, summary)
+ * - warn: scene can render but has low-confidence or missing preferred visual
+ * - blocked: required visual scene lacks a valid image and does not allow fallback
+ */
+
+/**
+ * Scene types that are allowed to use intentional text/color fallback
+ * without being counted as missing visuals.
+ */
+const FALLBACK_ALLOWED_TYPES = new Set([
+  'intro',
+  'end_card',
+  'transition',
+  'summary',
+  'title',
+  'recap',
+]);
+
+/**
+ * Scene types that require real image visuals for professional output.
+ */
+const IMAGE_REQUIRED_TYPES = new Set([
+  'setup_step',
+  'component',
+  'scoring',
+  'gameplay',
+  'example',
+]);
+
+const DEFAULT_CONFIDENCE_THRESHOLD = 0.5;
+
+/**
+ * Classify a single scene's visual coverage.
+ */
+function classifyScene(scene, options = {}) {
+  const threshold = options.confidenceThreshold || DEFAULT_CONFIDENCE_THRESHOLD;
+  const sceneType = (scene.type || '').toLowerCase();
+  const hasExplicitImage = Boolean(scene.imageId || scene.imageRef);
+  const confidence = scene.visualMatchConfidence ?? (hasExplicitImage ? 1.0 : 0);
+  const hasBackground = Boolean(scene.background?.image);
+
+  // Explicit image or high-confidence match
+  if (hasExplicitImage && confidence >= threshold) {
+    return {
+      sceneId: scene.id,
+      classification: 'covered',
+      confidence,
+      reason: scene.visualMatchReason || 'explicit-image',
+      warning: null,
+    };
+  }
+
+  // Scene has a resolved background image already (from adapter)
+  if (hasBackground) {
+    return {
+      sceneId: scene.id,
+      classification: 'covered',
+      confidence: confidence || 0.8,
+      reason: 'background-image-present',
+      warning: null,
+    };
+  }
+
+  // Fallback-allowed scene types
+  if (FALLBACK_ALLOWED_TYPES.has(sceneType)) {
+    return {
+      sceneId: scene.id,
+      classification: 'intentionalFallback',
+      confidence: 0,
+      reason: `scene-type-allows-fallback:${sceneType}`,
+      warning: null,
+    };
+  }
+
+  // Low-confidence match on a required type
+  if (hasExplicitImage && confidence < threshold) {
+    return {
+      sceneId: scene.id,
+      classification: 'warn',
+      confidence,
+      reason: `low-confidence-match:${scene.visualMatchReason || 'unknown'}`,
+      warning: `Scene '${scene.id}': matched image has low confidence (${confidence.toFixed(2)})`,
+    };
+  }
+
+  // Required type with no image at all
+  if (IMAGE_REQUIRED_TYPES.has(sceneType)) {
+    return {
+      sceneId: scene.id,
+      classification: 'blocked',
+      confidence: 0,
+      reason: 'required-visual-missing',
+      warning: `Scene '${scene.id}' (type: ${sceneType}): requires image but none matched`,
+    };
+  }
+
+  // Unknown type with no image — warn but don't block
+  return {
+    sceneId: scene.id,
+    classification: 'warn',
+    confidence: 0,
+    reason: 'no-image-unknown-type',
+    warning: `Scene '${scene.id}' (type: ${sceneType || 'unknown'}): no image available`,
+  };
+}
+
+/**
+ * Validate visual coverage for all storyboard scenes.
+ *
+ * @param {Array} scenes - Matched scenes (output of matchScenesToImages or storyboard scenes with image refs)
+ * @param {Object} [options] - { confidenceThreshold, strict }
+ * @returns {{ status, coverageRatio, coveredCount, fallbackCount, warningCount, blockedCount, scenes, warnings }}
+ */
+export function validateStoryboardVisualCoverage(scenes = [], options = {}) {
+  const perScene = scenes.map((scene) => classifyScene(scene, options));
+
+  const coveredCount = perScene.filter((s) => s.classification === 'covered').length;
+  const fallbackCount = perScene.filter((s) => s.classification === 'intentionalFallback').length;
+  const warningCount = perScene.filter((s) => s.classification === 'warn').length;
+  const blockedCount = perScene.filter((s) => s.classification === 'blocked').length;
+
+  const totalScenes = scenes.length;
+  const coverageRatio = totalScenes > 0 ? (coveredCount + fallbackCount) / totalScenes : 1;
+
+  const warnings = perScene
+    .filter((s) => s.warning)
+    .map((s) => s.warning);
+
+  let status;
+  if (blockedCount > 0) {
+    status = options.strict ? 'blocked' : 'warn';
+  } else if (warningCount > 0) {
+    status = 'warn';
+  } else {
+    status = 'pass';
+  }
+
+  return {
+    status,
+    coverageRatio,
+    coveredCount,
+    fallbackCount,
+    warningCount,
+    blockedCount,
+    totalScenes,
+    scenes: perScene,
+    warnings,
+  };
+}
+
+export {
+  classifyScene,
+  FALLBACK_ALLOWED_TYPES,
+  IMAGE_REQUIRED_TYPES,
+  DEFAULT_CONFIDENCE_THRESHOLD,
+};

--- a/tests/services/storyboardVisualCoverage.test.js
+++ b/tests/services/storyboardVisualCoverage.test.js
@@ -1,0 +1,146 @@
+/**
+ * Tests for storyboard visual coverage validator.
+ */
+
+let validateStoryboardVisualCoverage, classifyScene;
+
+beforeAll(async () => {
+  const mod = await import('../../src/services/storyboardVisualCoverage.js');
+  validateStoryboardVisualCoverage = mod.validateStoryboardVisualCoverage;
+  classifyScene = mod.classifyScene;
+});
+
+describe('storyboardVisualCoverage', () => {
+  describe('classifyScene', () => {
+    test('explicit high-confidence image is covered', () => {
+      const scene = { id: 's1', type: 'setup_step', imageId: 'img-1', visualMatchConfidence: 0.9, visualMatchReason: 'component-id-match' };
+      const result = classifyScene(scene);
+      expect(result.classification).toBe('covered');
+      expect(result.confidence).toBe(0.9);
+    });
+
+    test('scene with background image is covered', () => {
+      const scene = { id: 's1', type: 'setup_step', background: { image: '/path/to/img.png' } };
+      const result = classifyScene(scene);
+      expect(result.classification).toBe('covered');
+    });
+
+    test('intro scene without image is intentionalFallback', () => {
+      const scene = { id: 's1', type: 'intro' };
+      const result = classifyScene(scene);
+      expect(result.classification).toBe('intentionalFallback');
+      expect(result.reason).toContain('intro');
+    });
+
+    test('end_card scene without image is intentionalFallback', () => {
+      const scene = { id: 's1', type: 'end_card' };
+      const result = classifyScene(scene);
+      expect(result.classification).toBe('intentionalFallback');
+    });
+
+    test('setup_step without image is blocked', () => {
+      const scene = { id: 's1', type: 'setup_step' };
+      const result = classifyScene(scene);
+      expect(result.classification).toBe('blocked');
+      expect(result.warning).toContain('requires image');
+    });
+
+    test('component scene without image is blocked', () => {
+      const scene = { id: 's1', type: 'component' };
+      const result = classifyScene(scene);
+      expect(result.classification).toBe('blocked');
+    });
+
+    test('low-confidence match produces warn', () => {
+      const scene = { id: 's1', type: 'setup_step', imageId: 'img-1', visualMatchConfidence: 0.3, visualMatchReason: 'heuristic' };
+      const result = classifyScene(scene);
+      expect(result.classification).toBe('warn');
+      expect(result.warning).toContain('low confidence');
+    });
+
+    test('unknown type without image produces warn (not block)', () => {
+      const scene = { id: 's1', type: 'mystery' };
+      const result = classifyScene(scene);
+      expect(result.classification).toBe('warn');
+    });
+  });
+
+  describe('validateStoryboardVisualCoverage', () => {
+    test('all scenes covered returns pass', () => {
+      const scenes = [
+        { id: 's1', type: 'intro' },
+        { id: 's2', type: 'setup_step', imageId: 'img-1', visualMatchConfidence: 0.9 },
+        { id: 's3', type: 'end_card' },
+      ];
+      const result = validateStoryboardVisualCoverage(scenes);
+      expect(result.status).toBe('pass');
+      expect(result.coveredCount).toBe(1);
+      expect(result.fallbackCount).toBe(2);
+      expect(result.warningCount).toBe(0);
+      expect(result.blockedCount).toBe(0);
+      expect(result.coverageRatio).toBe(1);
+    });
+
+    test('blocked scene produces warn status by default', () => {
+      const scenes = [
+        { id: 's1', type: 'intro' },
+        { id: 's2', type: 'setup_step' },  // no image → blocked
+      ];
+      const result = validateStoryboardVisualCoverage(scenes);
+      expect(result.status).toBe('warn');
+      expect(result.blockedCount).toBe(1);
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+
+    test('strict mode blocks on required missing visual', () => {
+      const scenes = [
+        { id: 's1', type: 'setup_step' },  // no image → blocked
+      ];
+      const result = validateStoryboardVisualCoverage(scenes, { strict: true });
+      expect(result.status).toBe('blocked');
+    });
+
+    test('coverage ratio reflects covered + fallback over total', () => {
+      const scenes = [
+        { id: 's1', type: 'intro' },                    // fallback
+        { id: 's2', type: 'setup_step', imageId: 'x', visualMatchConfidence: 0.9 },  // covered
+        { id: 's3', type: 'scoring' },                   // blocked
+        { id: 's4', type: 'end_card' },                  // fallback
+      ];
+      const result = validateStoryboardVisualCoverage(scenes);
+      expect(result.coveredCount).toBe(1);
+      expect(result.fallbackCount).toBe(2);
+      expect(result.blockedCount).toBe(1);
+      expect(result.coverageRatio).toBe(0.75);
+    });
+
+    test('empty scenes returns pass with 100% coverage', () => {
+      const result = validateStoryboardVisualCoverage([]);
+      expect(result.status).toBe('pass');
+      expect(result.coverageRatio).toBe(1);
+      expect(result.totalScenes).toBe(0);
+    });
+
+    test('warnings contain scene IDs and types', () => {
+      const scenes = [
+        { id: 'scene-setup-tokens', type: 'setup_step' },
+      ];
+      const result = validateStoryboardVisualCoverage(scenes);
+      expect(result.warnings[0]).toContain('scene-setup-tokens');
+      expect(result.warnings[0]).toContain('setup_step');
+    });
+
+    test('per-scene diagnostics are available', () => {
+      const scenes = [
+        { id: 's1', type: 'intro' },
+        { id: 's2', type: 'setup_step', imageId: 'img', visualMatchConfidence: 0.8 },
+      ];
+      const result = validateStoryboardVisualCoverage(scenes);
+      expect(result.scenes).toHaveLength(2);
+      expect(result.scenes[0].sceneId).toBe('s1');
+      expect(result.scenes[0].classification).toBe('intentionalFallback');
+      expect(result.scenes[1].sceneId).toBe('s2');
+      expect(result.scenes[1].classification).toBe('covered');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Pre-render visual coverage validator that classifies each storyboard scene and produces operator diagnostics before render begins.

### Coverage classifications

| Class | Meaning | Example scene types |
|---|---|---|
| **covered** | Has validated image (confidence ≥ threshold) | setup_step with matched component image |
| **intentionalFallback** | Type allows text/color-only | intro, end_card, transition |
| **warn** | Can render but operator should review | low-confidence match, unknown type |
| **blocked** | Required visual missing, no fallback allowed | setup_step, component, scoring without image |

### \alidateStoryboardVisualCoverage(scenes, options)\ returns:

- \status\: pass / warn / blocked
- \coverageRatio\: (covered + fallback) / total
- Per-class counts
- Per-scene diagnostics (sceneId, classification, confidence, reason, warning)
- Summary warnings for operator display

### Strict mode

When \{ strict: true }\ is passed, blocked scenes prevent render (status = 'blocked').
Default mode warns but allows render to proceed.

### Tests (15 new)

- classifyScene: covered, intentionalFallback, blocked, warn paths
- validateStoryboardVisualCoverage: pass, warn, blocked status; strict mode; coverage ratio; empty input; diagnostic format

### Stack

- PRs #395–#402 (render + image infrastructure)
- **This PR** → PR #402 (visual coverage validation)

All 27 suites, 157 tests pass.

### Next step

Professional scene composition rules — deterministic layout for validated images as backgrounds/overlays instead of simple full-background placement.