### PR TITLE
feat: deterministic motion and pacing primitives

### DIFF
--- a/src/services/sceneMotionRules.js
+++ b/src/services/sceneMotionRules.js
@@ -1,0 +1,202 @@
+/**
+ * Deterministic motion and pacing primitives for composed tutorial scenes.
+ *
+ * Assigns subtle, instructional motion profiles based on scene type, layout,
+ * duration, and image availability. All motion is deterministic and testable.
+ *
+ * Supported motion types:
+ * - hold: static frame (no motion)
+ * - slowZoomIn: gentle 5% zoom over scene duration
+ * - slowZoomOut: gentle zoom from 105% to 100%
+ * - panLeft / panRight / panUp / panDown: subtle directional pan
+ * - kenBurns: combined slow zoom + pan for interest
+ *
+ * Transitions:
+ * - cut: instant transition (default)
+ * - crossfade: smooth blend between scenes
+ */
+
+/** Minimum scene duration (seconds) to allow any motion beyond hold. */
+const MIN_MOTION_DURATION = 2.5;
+
+/** Maximum zoom scale factor (1.0 = no zoom, 1.05 = 5% zoom). */
+const MAX_ZOOM_SCALE = 1.08;
+const DEFAULT_ZOOM_SCALE = 1.05;
+
+/** Maximum pan distance as fraction of frame dimension. */
+const MAX_PAN_FRACTION = 0.05;
+
+/** Crossfade duration in seconds. */
+const DEFAULT_CROSSFADE_SEC = 0.5;
+
+/**
+ * Layout-to-motion preference mapping.
+ */
+const LAYOUT_MOTION_MAP = {
+  fullBleed: 'slowZoomIn',
+  imageLeftTextRight: 'hold',
+  imageRightTextLeft: 'hold',
+  topImageBottomText: 'slowZoomOut',
+  centerFocus: 'slowZoomIn',
+  textOnly: 'hold',
+};
+
+/**
+ * Scene type to motion preference (used when layout isn't available).
+ */
+const TYPE_MOTION_MAP = {
+  intro: 'hold',
+  end_card: 'hold',
+  transition: 'hold',
+  summary: 'hold',
+  setup_step: 'slowZoomIn',
+  component: 'hold',
+  scoring: 'slowZoomOut',
+  gameplay: 'panRight',
+  example: 'slowZoomIn',
+};
+
+/**
+ * Scene type to transition preference.
+ */
+const TYPE_TRANSITION_MAP = {
+  intro: { in: 'crossfade', out: 'crossfade' },
+  end_card: { in: 'crossfade', out: 'cut' },
+  transition: { in: 'crossfade', out: 'crossfade' },
+  setup_step: { in: 'cut', out: 'cut' },
+  component: { in: 'cut', out: 'cut' },
+  scoring: { in: 'crossfade', out: 'cut' },
+  gameplay: { in: 'cut', out: 'cut' },
+  example: { in: 'cut', out: 'cut' },
+};
+
+/**
+ * Select the motion type for a scene.
+ */
+function selectMotionType(scene) {
+  // Explicit override
+  if (scene.motionType) return scene.motionType;
+
+  const layout = scene.composition?.layout || scene.layout;
+  const sceneType = (scene.type || '').toLowerCase();
+  const duration = scene.durationSec || 0;
+
+  // Short scenes always hold
+  if (duration < MIN_MOTION_DURATION) return 'hold';
+
+  // No image → always hold
+  const hasImage = Boolean(scene.imageId || scene.imageRef || scene.background?.image);
+  if (!hasImage) return 'hold';
+
+  // Prefer layout-based selection, fall back to type-based
+  if (layout && LAYOUT_MOTION_MAP[layout]) return LAYOUT_MOTION_MAP[layout];
+  if (sceneType && TYPE_MOTION_MAP[sceneType]) return TYPE_MOTION_MAP[sceneType];
+
+  return 'hold';
+}
+
+/**
+ * Build motion parameters for the selected motion type.
+ */
+function buildMotionParams(motionType, scene) {
+  const duration = scene.durationSec || 0;
+
+  switch (motionType) {
+    case 'slowZoomIn':
+      return { startScale: 1.0, endScale: DEFAULT_ZOOM_SCALE, easing: 'linear' };
+    case 'slowZoomOut':
+      return { startScale: DEFAULT_ZOOM_SCALE, endScale: 1.0, easing: 'linear' };
+    case 'panLeft':
+      return { panDirection: 'left', panFraction: MAX_PAN_FRACTION, easing: 'linear' };
+    case 'panRight':
+      return { panDirection: 'right', panFraction: MAX_PAN_FRACTION, easing: 'linear' };
+    case 'panUp':
+      return { panDirection: 'up', panFraction: MAX_PAN_FRACTION, easing: 'linear' };
+    case 'panDown':
+      return { panDirection: 'down', panFraction: MAX_PAN_FRACTION, easing: 'linear' };
+    case 'kenBurns':
+      return { startScale: 1.0, endScale: DEFAULT_ZOOM_SCALE, panDirection: 'right', panFraction: 0.03, easing: 'linear' };
+    case 'hold':
+    default:
+      return { startScale: 1.0, endScale: 1.0, easing: 'none' };
+  }
+}
+
+/**
+ * Select transitions for a scene.
+ */
+function selectTransitions(scene) {
+  const sceneType = (scene.type || '').toLowerCase();
+  const prefs = TYPE_TRANSITION_MAP[sceneType] || { in: 'cut', out: 'cut' };
+
+  return {
+    transitionIn: scene.transitionIn || prefs.in,
+    transitionOut: scene.transitionOut || prefs.out,
+    crossfadeDuration: DEFAULT_CROSSFADE_SEC,
+  };
+}
+
+/**
+ * Assign motion metadata to a single scene.
+ *
+ * @param {Object} scene - Composed scene with layout, type, duration, images
+ * @returns {{ motionType, motionParams, transitionIn, transitionOut, crossfadeDuration, motionDuration, holdDuration, motionWarnings }}
+ */
+export function assignSceneMotion(scene) {
+  const duration = scene.durationSec || 0;
+  const motionType = selectMotionType(scene);
+  const motionParams = buildMotionParams(motionType, scene);
+  const transitions = selectTransitions(scene);
+  const warnings = [];
+
+  // Calculate effective motion/hold durations
+  const transitionTime = (transitions.transitionIn === 'crossfade' ? transitions.crossfadeDuration : 0)
+    + (transitions.transitionOut === 'crossfade' ? transitions.crossfadeDuration : 0);
+
+  if (transitionTime >= duration * 0.6 && duration > 0) {
+    warnings.push(`Scene '${scene.id}': transitions consume >60% of duration (${transitionTime.toFixed(1)}s / ${duration}s)`);
+  }
+
+  const motionDuration = motionType === 'hold' ? 0 : Math.max(0, duration - transitionTime);
+  const holdDuration = motionType === 'hold' ? duration : 0;
+
+  return {
+    motionType,
+    motionParams,
+    ...transitions,
+    motionDuration,
+    holdDuration,
+    motionWarnings: warnings.length > 0 ? warnings : undefined,
+  };
+}
+
+/**
+ * Apply motion rules to all storyboard scenes.
+ *
+ * @param {Array} scenes - Composed scenes
+ * @returns {{ scenesWithMotion, warnings }}
+ */
+export function applyMotionToStoryboard(scenes = []) {
+  const warnings = [];
+
+  const scenesWithMotion = scenes.map((scene) => {
+    const motion = assignSceneMotion(scene);
+    if (motion.motionWarnings) {
+      warnings.push(...motion.motionWarnings);
+    }
+    return { ...scene, motion };
+  });
+
+  return { scenesWithMotion, warnings };
+}
+
+export {
+  selectMotionType,
+  buildMotionParams,
+  selectTransitions,
+  LAYOUT_MOTION_MAP,
+  TYPE_MOTION_MAP,
+  MIN_MOTION_DURATION,
+  DEFAULT_ZOOM_SCALE,
+  MAX_PAN_FRACTION,
+};

--- a/tests/services/sceneMotionRules.test.js
+++ b/tests/services/sceneMotionRules.test.js
@@ -1,0 +1,144 @@
+/**
+ * Tests for deterministic motion and pacing primitives.
+ */
+
+let assignSceneMotion, applyMotionToStoryboard, selectMotionType, MIN_MOTION_DURATION;
+
+beforeAll(async () => {
+  const mod = await import('../../src/services/sceneMotionRules.js');
+  assignSceneMotion = mod.assignSceneMotion;
+  applyMotionToStoryboard = mod.applyMotionToStoryboard;
+  selectMotionType = mod.selectMotionType;
+  MIN_MOTION_DURATION = mod.MIN_MOTION_DURATION;
+});
+
+describe('sceneMotionRules', () => {
+  describe('selectMotionType', () => {
+    test('explicit motionType override is preserved', () => {
+      const scene = { id: 's1', type: 'setup_step', imageId: 'img', durationSec: 5, motionType: 'panLeft' };
+      expect(selectMotionType(scene)).toBe('panLeft');
+    });
+
+    test('short scene always returns hold', () => {
+      const scene = { id: 's1', type: 'setup_step', imageId: 'img', durationSec: 1.5 };
+      expect(selectMotionType(scene)).toBe('hold');
+    });
+
+    test('scene without image always returns hold', () => {
+      const scene = { id: 's1', type: 'setup_step', durationSec: 8 };
+      expect(selectMotionType(scene)).toBe('hold');
+    });
+
+    test('fullBleed layout selects slowZoomIn', () => {
+      const scene = { id: 's1', type: 'setup_step', imageId: 'img', durationSec: 5, composition: { layout: 'fullBleed' } };
+      expect(selectMotionType(scene)).toBe('slowZoomIn');
+    });
+
+    test('topImageBottomText layout selects slowZoomOut', () => {
+      const scene = { id: 's1', type: 'scoring', imageId: 'img', durationSec: 5, composition: { layout: 'topImageBottomText' } };
+      expect(selectMotionType(scene)).toBe('slowZoomOut');
+    });
+
+    test('imageLeftTextRight layout selects hold', () => {
+      const scene = { id: 's1', type: 'component', imageId: 'img', durationSec: 5, composition: { layout: 'imageLeftTextRight' } };
+      expect(selectMotionType(scene)).toBe('hold');
+    });
+
+    test('textOnly layout selects hold', () => {
+      const scene = { id: 's1', type: 'intro', durationSec: 5, composition: { layout: 'textOnly' } };
+      expect(selectMotionType(scene)).toBe('hold');
+    });
+
+    test('gameplay type without layout selects panRight', () => {
+      const scene = { id: 's1', type: 'gameplay', imageId: 'img', durationSec: 5 };
+      expect(selectMotionType(scene)).toBe('panRight');
+    });
+  });
+
+  describe('assignSceneMotion', () => {
+    test('returns complete motion metadata', () => {
+      const scene = { id: 's1', type: 'setup_step', imageId: 'img', durationSec: 6, composition: { layout: 'fullBleed' } };
+      const motion = assignSceneMotion(scene);
+      expect(motion.motionType).toBe('slowZoomIn');
+      expect(motion.motionParams.startScale).toBe(1.0);
+      expect(motion.motionParams.endScale).toBeGreaterThan(1.0);
+      expect(motion.transitionIn).toBe('cut');
+      expect(motion.transitionOut).toBe('cut');
+      expect(motion.motionDuration).toBeGreaterThan(0);
+      expect(motion.holdDuration).toBe(0);
+    });
+
+    test('hold scene has holdDuration equal to scene duration', () => {
+      const scene = { id: 's1', type: 'intro', durationSec: 4 };
+      const motion = assignSceneMotion(scene);
+      expect(motion.motionType).toBe('hold');
+      expect(motion.holdDuration).toBe(4);
+      expect(motion.motionDuration).toBe(0);
+    });
+
+    test('intro scene gets crossfade transitions', () => {
+      const scene = { id: 's1', type: 'intro', durationSec: 5 };
+      const motion = assignSceneMotion(scene);
+      expect(motion.transitionIn).toBe('crossfade');
+      expect(motion.transitionOut).toBe('crossfade');
+      expect(motion.crossfadeDuration).toBeGreaterThan(0);
+    });
+
+    test('warns when transitions consume too much duration', () => {
+      const scene = { id: 's1', type: 'intro', durationSec: 1.2 };
+      const motion = assignSceneMotion(scene);
+      expect(motion.motionWarnings).toBeDefined();
+      expect(motion.motionWarnings[0]).toContain('transitions consume');
+    });
+
+    test('no warning for normal duration scenes', () => {
+      const scene = { id: 's1', type: 'setup_step', imageId: 'img', durationSec: 8 };
+      const motion = assignSceneMotion(scene);
+      expect(motion.motionWarnings).toBeUndefined();
+    });
+
+    test('explicit transitionIn/Out overrides are preserved', () => {
+      const scene = { id: 's1', type: 'intro', durationSec: 5, transitionIn: 'cut', transitionOut: 'cut' };
+      const motion = assignSceneMotion(scene);
+      expect(motion.transitionIn).toBe('cut');
+      expect(motion.transitionOut).toBe('cut');
+    });
+  });
+
+  describe('applyMotionToStoryboard', () => {
+    test('applies motion to all scenes', () => {
+      const scenes = [
+        { id: 's1', type: 'intro', durationSec: 4 },
+        { id: 's2', type: 'setup_step', imageId: 'img', durationSec: 6, composition: { layout: 'fullBleed' } },
+        { id: 's3', type: 'end_card', durationSec: 3 },
+      ];
+      const { scenesWithMotion, warnings } = applyMotionToStoryboard(scenes);
+      expect(scenesWithMotion).toHaveLength(3);
+      expect(scenesWithMotion[0].motion.motionType).toBe('hold');
+      expect(scenesWithMotion[1].motion.motionType).toBe('slowZoomIn');
+      expect(scenesWithMotion[2].motion.motionType).toBe('hold');
+    });
+
+    test('collects warnings across scenes', () => {
+      const scenes = [
+        { id: 's1', type: 'intro', durationSec: 0.8 },
+      ];
+      const { warnings } = applyMotionToStoryboard(scenes);
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    test('empty input returns empty arrays', () => {
+      const { scenesWithMotion, warnings } = applyMotionToStoryboard([]);
+      expect(scenesWithMotion).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('preserves original scene fields', () => {
+      const scenes = [{ id: 's1', type: 'intro', durationSec: 5, overlays: [{ text: 'hi' }] }];
+      const { scenesWithMotion } = applyMotionToStoryboard(scenes);
+      expect(scenesWithMotion[0].id).toBe('s1');
+      expect(scenesWithMotion[0].overlays[0].text).toBe('hi');
+      expect(scenesWithMotion[0].motion).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds subtle, instructional motion profiles for composed scenes so tutorials feel dynamic rather than static-slide based.

### Motion types

| Type | Effect | When used |
|---|---|---|
| hold | Static frame | Short scenes, no-image, split layouts |
| slowZoomIn | 5% zoom over duration | Setup overview, fullBleed, examples |
| slowZoomOut | 105%→100% | Scoring, wrap-up |
| panLeft/Right/Up/Down | Subtle directional shift | Gameplay action |
| kenBurns | Combined zoom+pan | Manual override |

### Transitions

| Type | When used |
|---|---|
| cut | Default (setup, component, gameplay) |
| crossfade | Intro, end_card, scoring transitions |

### Safety rules

- Scenes < 2.5s always get \hold\ (no motion on very short scenes)
- No-image scenes always get \hold\
- Transitions never consume >60% of duration (produces warning)
- Explicit \motionType\/\	ransitionIn\/\	ransitionOut\ overrides are preserved

### Module: \src/services/sceneMotionRules.js\

- \ssignSceneMotion(scene)\: returns full motion metadata
- \pplyMotionToStoryboard(scenes)\: batch application with warnings

### Tests (18 new)

- Motion selection for all layout/type combinations
- Duration safeguards
- Explicit override preservation
- Transition timing warnings
- Batch application and field preservation

### Stack

- PRs #395–#404 (full render infrastructure)
- **This PR** → PR #404 (motion primitives)

All 29 suites, 194 tests pass.

### Next step

Overlay typography and readability rules.