### PR TITLE
feat: ElevenLabs narration audio asset integration and sidecar metadata

### DIFF
--- a/src/services/narrationAudioAssets.js
+++ b/src/services/narrationAudioAssets.js
@@ -1,0 +1,162 @@
+/**
+ * Narration audio asset normalization, scene mapping, and validation.
+ *
+ * Provides a clean integration layer for ElevenLabs-compatible voice assets
+ * without requiring live API calls. Supports local/fixture audio files and
+ * validates metadata alignment with storyboard scenes and captions.
+ */
+
+import crypto from 'crypto';
+
+const SUPPORTED_AUDIO_EXTENSIONS = ['.mp3', '.wav', '.m4a', '.ogg', '.aac', '.webm'];
+const SUPPORTED_MIME_TYPES = ['audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/ogg', 'audio/aac', 'audio/webm'];
+
+/**
+ * Compute a hash of narration source text for mismatch detection.
+ */
+function computeTextHash(text) {
+  if (!text) return null;
+  return crypto.createHash('sha256').update(text.trim()).digest('hex').slice(0, 16);
+}
+
+/**
+ * Normalize a narration audio asset into the canonical contract shape.
+ */
+export function normalizeNarrationAsset(asset = {}) {
+  return {
+    id: asset.id || `narration-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    sceneId: asset.sceneId || null,
+    segmentId: asset.segmentId || null,
+    provider: asset.provider || 'manual',
+    providerVoiceId: asset.providerVoiceId || asset.voice_id || null,
+    modelId: asset.modelId || asset.model_id || 'eleven_multilingual_v2',
+    language: asset.language || 'en',
+    textHash: asset.textHash || computeTextHash(asset.sourceText || asset.text),
+    sourceText: asset.sourceText || asset.text || null,
+    filePath: asset.filePath || asset.file || asset.path || null,
+    mimeType: asset.mimeType || asset.mime_type || null,
+    durationMs: asset.durationMs || asset.duration_ms || null,
+    sampleRate: asset.sampleRate || asset.sample_rate || null,
+    channels: asset.channels || null,
+    status: asset.status || (asset.filePath || asset.file || asset.path ? 'ready' : 'pending'),
+    warnings: [],
+  };
+}
+
+/**
+ * Map narration audio assets to storyboard scenes.
+ *
+ * @param {Array} scenes - Storyboard scenes with id, segmentId
+ * @param {Array} audioAssets - Normalized narration assets
+ * @returns {{ mappedScenes, unmappedAssets, warnings }}
+ */
+export function mapNarrationToScenes(scenes = [], audioAssets = []) {
+  const warnings = [];
+  const usedAssetIds = new Set();
+
+  const mappedScenes = scenes.map((scene) => {
+    // Find matching audio: prefer sceneId match, then segmentId
+    let match = audioAssets.find((a) => a.sceneId && a.sceneId === scene.id);
+    if (!match) {
+      match = audioAssets.find((a) => a.segmentId && a.segmentId === (scene.segmentId || scene.id));
+    }
+
+    if (match) {
+      usedAssetIds.add(match.id);
+      return { ...scene, narrationAudio: match };
+    }
+
+    // Check if scene has narration text but no audio
+    const hasNarration = Boolean(scene.narration || scene.scriptText ||
+      (scene.overlays || []).some((o) => o.type === 'body' && o.text));
+
+    if (hasNarration) {
+      warnings.push(`Scene '${scene.id}': has narration text but no audio asset mapped`);
+    }
+
+    return { ...scene, narrationAudio: null };
+  });
+
+  const unmappedAssets = audioAssets.filter((a) => !usedAssetIds.has(a.id));
+  if (unmappedAssets.length > 0) {
+    warnings.push(`${unmappedAssets.length} narration asset(s) not mapped to any scene: ${unmappedAssets.map((a) => a.id).join(', ')}`);
+  }
+
+  return { mappedScenes, unmappedAssets, warnings };
+}
+
+/**
+ * Validate narration audio assets for render readiness.
+ *
+ * @param {Array} audioAssets - Normalized narration assets
+ * @param {Array} [scenes] - Optional scenes for duration/language alignment
+ * @returns {{ valid, warnings, summary }}
+ */
+export function validateNarrationAssets(audioAssets = [], scenes = []) {
+  const warnings = [];
+  let durationMismatchCount = 0;
+
+  for (const asset of audioAssets) {
+    // File path check
+    if (asset.status === 'ready' && !asset.filePath) {
+      warnings.push(`Asset '${asset.id}': status is ready but no filePath`);
+    }
+
+    // Extension check
+    if (asset.filePath) {
+      const ext = (asset.filePath.match(/\.[^.]+$/) || [''])[0].toLowerCase();
+      if (!SUPPORTED_AUDIO_EXTENSIONS.includes(ext)) {
+        warnings.push(`Asset '${asset.id}': unsupported extension '${ext}'`);
+      }
+    }
+
+    // Duration check
+    if (asset.durationMs != null && asset.durationMs <= 0) {
+      warnings.push(`Asset '${asset.id}': invalid duration ${asset.durationMs}ms`);
+    }
+
+    // Scene duration alignment
+    if (asset.sceneId && asset.durationMs) {
+      const scene = scenes.find((s) => s.id === asset.sceneId);
+      if (scene && scene.durationSec) {
+        const sceneDurationMs = scene.durationSec * 1000;
+        const tolerance = sceneDurationMs * 0.3; // 30% tolerance
+        if (Math.abs(asset.durationMs - sceneDurationMs) > tolerance) {
+          warnings.push(`Asset '${asset.id}': duration ${asset.durationMs}ms differs from scene '${scene.id}' duration ${sceneDurationMs}ms by >30%`);
+          durationMismatchCount++;
+        }
+      }
+    }
+
+    // Language alignment with scene captions
+    if (asset.language && asset.sceneId) {
+      const scene = scenes.find((s) => s.id === asset.sceneId);
+      if (scene && scene.captionLanguage && scene.captionLanguage !== asset.language) {
+        warnings.push(`Asset '${asset.id}': language '${asset.language}' differs from scene caption language '${scene.captionLanguage}'`);
+      }
+    }
+  }
+
+  const mappedCount = audioAssets.filter((a) => a.sceneId || a.segmentId).length;
+  const readyCount = audioAssets.filter((a) => a.status === 'ready').length;
+
+  return {
+    valid: warnings.length === 0,
+    warnings,
+    summary: {
+      audioAssetCount: audioAssets.length,
+      mappedSceneCount: mappedCount,
+      readyCount,
+      pendingCount: audioAssets.length - readyCount,
+      durationMismatchCount,
+      provider: audioAssets[0]?.provider || null,
+      language: audioAssets[0]?.language || null,
+    },
+  };
+}
+
+export {
+  computeTextHash,
+  SUPPORTED_AUDIO_EXTENSIONS,
+  SUPPORTED_MIME_TYPES,
+};

--- a/tests/services/narrationAudioAssets.test.js
+++ b/tests/services/narrationAudioAssets.test.js
@@ -1,0 +1,179 @@
+/**
+ * Tests for narration audio asset normalization, scene mapping, and validation.
+ */
+
+let normalizeNarrationAsset, mapNarrationToScenes, validateNarrationAssets, computeTextHash;
+
+beforeAll(async () => {
+  const mod = await import('../../src/services/narrationAudioAssets.js');
+  normalizeNarrationAsset = mod.normalizeNarrationAsset;
+  mapNarrationToScenes = mod.mapNarrationToScenes;
+  validateNarrationAssets = mod.validateNarrationAssets;
+  computeTextHash = mod.computeTextHash;
+});
+
+describe('narrationAudioAssets', () => {
+  describe('normalizeNarrationAsset', () => {
+    test('normalizes fixture/manual asset', () => {
+      const asset = normalizeNarrationAsset({
+        sceneId: 's1',
+        filePath: '/audio/scene1.mp3',
+        durationMs: 4500,
+        language: 'en',
+      });
+      expect(asset.sceneId).toBe('s1');
+      expect(asset.filePath).toBe('/audio/scene1.mp3');
+      expect(asset.durationMs).toBe(4500);
+      expect(asset.provider).toBe('manual');
+      expect(asset.status).toBe('ready');
+      expect(asset.id).toBeTruthy();
+    });
+
+    test('normalizes ElevenLabs-style metadata', () => {
+      const asset = normalizeNarrationAsset({
+        sceneId: 's2',
+        provider: 'elevenlabs',
+        voice_id: 'dllHSct4GokGc1AH9JwT',
+        model_id: 'eleven_multilingual_v2',
+        language: 'en',
+        sourceText: 'Welcome to the tutorial.',
+        file: '/audio/s2.mp3',
+        duration_ms: 3200,
+      });
+      expect(asset.provider).toBe('elevenlabs');
+      expect(asset.providerVoiceId).toBe('dllHSct4GokGc1AH9JwT');
+      expect(asset.modelId).toBe('eleven_multilingual_v2');
+      expect(asset.filePath).toBe('/audio/s2.mp3');
+      expect(asset.durationMs).toBe(3200);
+      expect(asset.textHash).toBeTruthy();
+    });
+
+    test('pending status when no file path', () => {
+      const asset = normalizeNarrationAsset({ sceneId: 's3', sourceText: 'Hello' });
+      expect(asset.status).toBe('pending');
+      expect(asset.filePath).toBeNull();
+    });
+
+    test('computes text hash from sourceText', () => {
+      const asset = normalizeNarrationAsset({ sourceText: 'Test text' });
+      expect(asset.textHash).toBeTruthy();
+      expect(asset.textHash.length).toBe(16);
+    });
+  });
+
+  describe('computeTextHash', () => {
+    test('returns consistent hash for same text', () => {
+      expect(computeTextHash('hello')).toBe(computeTextHash('hello'));
+    });
+
+    test('returns null for empty/null', () => {
+      expect(computeTextHash('')).toBeNull();
+      expect(computeTextHash(null)).toBeNull();
+    });
+
+    test('trims whitespace before hashing', () => {
+      expect(computeTextHash('  hello  ')).toBe(computeTextHash('hello'));
+    });
+  });
+
+  describe('mapNarrationToScenes', () => {
+    test('maps audio by sceneId', () => {
+      const scenes = [{ id: 's1', narration: 'Hello' }, { id: 's2', narration: 'World' }];
+      const assets = [
+        normalizeNarrationAsset({ sceneId: 's1', filePath: '/a.mp3' }),
+        normalizeNarrationAsset({ sceneId: 's2', filePath: '/b.mp3' }),
+      ];
+      const { mappedScenes, warnings } = mapNarrationToScenes(scenes, assets);
+      expect(mappedScenes[0].narrationAudio).toBeTruthy();
+      expect(mappedScenes[1].narrationAudio).toBeTruthy();
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('falls back to segmentId mapping', () => {
+      const scenes = [{ id: 'scene-setup', segmentId: 'setup' }];
+      const assets = [normalizeNarrationAsset({ segmentId: 'setup', filePath: '/x.mp3' })];
+      const { mappedScenes } = mapNarrationToScenes(scenes, assets);
+      expect(mappedScenes[0].narrationAudio).toBeTruthy();
+    });
+
+    test('warns when scene has narration text but no audio', () => {
+      const scenes = [{ id: 's1', narration: 'I need audio' }];
+      const assets = [];
+      const { mappedScenes, warnings } = mapNarrationToScenes(scenes, assets);
+      expect(mappedScenes[0].narrationAudio).toBeNull();
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings[0]).toContain('s1');
+    });
+
+    test('reports unmapped assets', () => {
+      const scenes = [{ id: 's1' }];
+      const assets = [normalizeNarrationAsset({ sceneId: 'other', filePath: '/x.mp3' })];
+      const { unmappedAssets, warnings } = mapNarrationToScenes(scenes, assets);
+      expect(unmappedAssets).toHaveLength(1);
+      expect(warnings.some((w) => w.includes('not mapped'))).toBe(true);
+    });
+
+    test('empty inputs return empty results', () => {
+      const { mappedScenes, warnings } = mapNarrationToScenes([], []);
+      expect(mappedScenes).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe('validateNarrationAssets', () => {
+    test('valid assets pass', () => {
+      const assets = [
+        normalizeNarrationAsset({ sceneId: 's1', filePath: '/audio.mp3', durationMs: 3000 }),
+      ];
+      const { valid, warnings } = validateNarrationAssets(assets);
+      expect(valid).toBe(true);
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('warns on ready status without filePath', () => {
+      const asset = normalizeNarrationAsset({ sceneId: 's1', filePath: '/x.mp3' });
+      asset.filePath = null; // Simulate corruption
+      const { valid, warnings } = validateNarrationAssets([asset]);
+      expect(valid).toBe(false);
+      expect(warnings[0]).toContain('filePath');
+    });
+
+    test('warns on unsupported extension', () => {
+      const assets = [normalizeNarrationAsset({ sceneId: 's1', filePath: '/audio.xyz' })];
+      const { warnings } = validateNarrationAssets(assets);
+      expect(warnings.some((w) => w.includes('unsupported extension'))).toBe(true);
+    });
+
+    test('warns on invalid duration', () => {
+      const assets = [normalizeNarrationAsset({ sceneId: 's1', filePath: '/a.mp3', durationMs: -100 })];
+      const { warnings } = validateNarrationAssets(assets);
+      expect(warnings.some((w) => w.includes('invalid duration'))).toBe(true);
+    });
+
+    test('warns on duration mismatch with scene', () => {
+      const assets = [normalizeNarrationAsset({ sceneId: 's1', filePath: '/a.mp3', durationMs: 10000 })];
+      const scenes = [{ id: 's1', durationSec: 3 }];
+      const { warnings, summary } = validateNarrationAssets(assets, scenes);
+      expect(warnings.some((w) => w.includes('differs from scene'))).toBe(true);
+      expect(summary.durationMismatchCount).toBe(1);
+    });
+
+    test('returns summary metadata', () => {
+      const assets = [
+        normalizeNarrationAsset({ sceneId: 's1', filePath: '/a.mp3', provider: 'elevenlabs', language: 'en' }),
+        normalizeNarrationAsset({ sceneId: 's2', sourceText: 'pending' }),
+      ];
+      const { summary } = validateNarrationAssets(assets);
+      expect(summary.audioAssetCount).toBe(2);
+      expect(summary.readyCount).toBe(1);
+      expect(summary.pendingCount).toBe(1);
+      expect(summary.provider).toBe('elevenlabs');
+      expect(summary.language).toBe('en');
+    });
+
+    test('empty assets are valid', () => {
+      const { valid } = validateNarrationAssets([]);
+      expect(valid).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Narration audio asset normalization, scene mapping, and validation layer supporting ElevenLabs-compatible metadata without live API dependency.

### Module: src/services/narrationAudioAssets.js

- normalizeNarrationAsset(): canonical shape with ElevenLabs fields (provider, voiceId, modelId, language, textHash, filePath, duration, status)
- mapNarrationToScenes(): maps assets by sceneId/segmentId, reports missing and unmapped
- validateNarrationAssets(): checks paths, extensions, durations, scene alignment (30% tolerance), language mismatches
- computeTextHash(): deterministic hash for source text mismatch detection
- Returns validation summary: counts, provider, language, mismatch stats

### Tests (19 new)

- Fixture/manual and ElevenLabs-style normalization
- SceneId and segmentId mapping with fallback
- Missing narration audio warnings
- Unmapped asset reporting
- Extension, duration, and alignment validation
- Summary metadata computation

### Stack

- PRs #395-#407 (full render infrastructure)
- This PR -> PR #407 (narration audio metadata)

32 of 33 suites pass (262 passed, 1 skipped). The 1 failing test (render_job_config_captions) is a pre-existing locale config loading issue unrelated to this change.

### Next step

Audio assembly and loudness validation foundation.