### PR TITLE
feat: audio mastering plan with loudness normalization and peak limiting

### DIFF
--- a/src/services/audioMasteringPlan.js
+++ b/src/services/audioMasteringPlan.js
@@ -1,0 +1,155 @@
+/**
+ * Audio mastering plan generation.
+ *
+ * Produces deterministic mastering metadata and FFmpeg filter plans for
+ * loudness normalization, true-peak limiting, and silence validation.
+ * Does not execute processing — returns planning/command metadata only.
+ */
+
+import path from 'path';
+
+/** Default mastering targets aligned with MOBIUS Elite audio standards. */
+const DEFAULT_MASTERING_TARGETS = {
+  targetIntegratedLufs: -14,
+  lufsTolerance: 0.5,
+  truePeakLimitDbtp: -1.0,
+  clippingLimitDbfs: 0.0,
+  silenceThresholdMs: 5000,
+  audioCodec: 'aac',
+  audioBitrate: '192k',
+  sampleRate: 48000,
+};
+
+/**
+ * Build an audio mastering plan from input audio and optional analyzer results.
+ *
+ * @param {string} inputAudioPath - Path to narration/muxed audio
+ * @param {Object} [analyzerResult] - { integratedLufs, truePeakDbtp, maxPeakDbfs, silenceSegments }
+ * @param {Object} [options] - Override targets, dryRun flag
+ * @returns {{ enabled, status, inputAudioPath, outputAudioPath, targets, analyzerStatus, ffmpegArgs, dryRun, duckingPreparation, warnings }}
+ */
+export function buildAudioMasteringPlan(inputAudioPath, analyzerResult = null, options = {}) {
+  const targets = { ...DEFAULT_MASTERING_TARGETS, ...options.targets };
+  const dryRun = options.dryRun ?? true;
+  const warnings = [];
+
+  // Validate input
+  if (!inputAudioPath) {
+    return {
+      enabled: false,
+      status: 'disabled',
+      inputAudioPath: null,
+      outputAudioPath: null,
+      targets,
+      analyzerStatus: 'missing',
+      ffmpegArgs: [],
+      dryRun,
+      duckingPreparation: buildDuckingMetadata(),
+      warnings: ['No input audio path provided'],
+    };
+  }
+
+  // Compute output path
+  const dir = path.dirname(inputAudioPath);
+  const baseName = path.basename(inputAudioPath, path.extname(inputAudioPath));
+  const outputAudioPath = path.join(dir, `${baseName}-mastered.m4a`);
+
+  // Analyze current state
+  let analyzerStatus = 'missing';
+  let status = 'warn';
+
+  if (analyzerResult) {
+    const { integratedLufs, truePeakDbtp, maxPeakDbfs, silenceSegments } = analyzerResult;
+
+    analyzerStatus = 'available';
+
+    // Clipping check
+    if (maxPeakDbfs != null && maxPeakDbfs >= targets.clippingLimitDbfs) {
+      status = 'fail';
+      warnings.push(`Clipping detected: ${maxPeakDbfs.toFixed(1)} dBFS >= ${targets.clippingLimitDbfs} dBFS`);
+    }
+
+    // True peak check
+    const peakValue = truePeakDbtp ?? maxPeakDbfs;
+    if (peakValue != null && peakValue > targets.truePeakLimitDbtp) {
+      if (status !== 'fail') status = 'fail';
+      warnings.push(`True peak ${peakValue.toFixed(1)} dBTP exceeds limit ${targets.truePeakLimitDbtp} dBTP — limiting required`);
+    }
+
+    // Loudness check
+    if (integratedLufs != null) {
+      const diff = Math.abs(integratedLufs - targets.targetIntegratedLufs);
+      if (diff > targets.lufsTolerance * 2) {
+        if (status !== 'fail') status = 'warn';
+        warnings.push(`Integrated loudness ${integratedLufs.toFixed(1)} LUFS far from target ${targets.targetIntegratedLufs} LUFS — normalization required`);
+      } else if (diff <= targets.lufsTolerance) {
+        if (status !== 'fail') status = 'pass';
+      } else {
+        if (status !== 'fail') status = 'warn';
+        warnings.push(`Integrated loudness ${integratedLufs.toFixed(1)} LUFS outside ±${targets.lufsTolerance} tolerance`);
+      }
+    }
+
+    // Silence check
+    if (Array.isArray(silenceSegments)) {
+      for (const seg of silenceSegments) {
+        const duration = (seg.endMs || 0) - (seg.startMs || 0);
+        if (duration > targets.silenceThresholdMs) {
+          warnings.push(`Silence at ${seg.startMs}ms–${seg.endMs}ms (${duration}ms) exceeds ${targets.silenceThresholdMs}ms`);
+        }
+      }
+    }
+  } else {
+    warnings.push('No analyzer data available — mastering plan is advisory only');
+    status = 'warn';
+  }
+
+  // Build FFmpeg loudnorm filter args
+  const ffmpegArgs = buildMasteringFfmpegArgs({
+    inputAudioPath,
+    outputAudioPath,
+    targets,
+  });
+
+  return {
+    enabled: true,
+    status,
+    inputAudioPath,
+    outputAudioPath,
+    targets,
+    analyzerStatus,
+    ffmpegArgs,
+    dryRun,
+    duckingPreparation: buildDuckingMetadata(),
+    warnings,
+  };
+}
+
+/**
+ * Build FFmpeg args for loudness normalization using loudnorm filter.
+ */
+function buildMasteringFfmpegArgs({ inputAudioPath, outputAudioPath, targets }) {
+  return [
+    '-hide_banner', '-loglevel', 'error', '-y',
+    '-i', inputAudioPath,
+    '-af', `loudnorm=I=${targets.targetIntegratedLufs}:TP=${targets.truePeakLimitDbtp}:LRA=11`,
+    '-ar', String(targets.sampleRate),
+    '-c:a', targets.audioCodec,
+    '-b:a', targets.audioBitrate,
+    outputAudioPath,
+  ];
+}
+
+/**
+ * Ducking preparation metadata (future-ready, not implemented yet).
+ */
+function buildDuckingMetadata() {
+  return {
+    duckingPrepared: false,
+    narrationPriority: true,
+    musicBedSupported: false,
+    recommendedMusicDuckDb: 18,
+  };
+}
+
+export { DEFAULT_MASTERING_TARGETS, buildMasteringFfmpegArgs, buildDuckingMetadata };

--- a/tests/services/audioMasteringPlan.test.js
+++ b/tests/services/audioMasteringPlan.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for audio mastering plan generation.
+ */
+
+let buildAudioMasteringPlan, DEFAULT_MASTERING_TARGETS;
+
+beforeAll(async () => {
+  const mod = await import('../../src/services/audioMasteringPlan.js');
+  buildAudioMasteringPlan = mod.buildAudioMasteringPlan;
+  DEFAULT_MASTERING_TARGETS = mod.DEFAULT_MASTERING_TARGETS;
+});
+
+describe('audioMasteringPlan', () => {
+  test('passes when analyzer shows audio within targets', () => {
+    const plan = buildAudioMasteringPlan('/audio/narration.mp3', {
+      integratedLufs: -14.2,
+      truePeakDbtp: -1.5,
+      maxPeakDbfs: -2.0,
+      silenceSegments: [],
+    });
+    expect(plan.enabled).toBe(true);
+    expect(plan.status).toBe('pass');
+    expect(plan.warnings).toHaveLength(0);
+    expect(plan.analyzerStatus).toBe('available');
+  });
+
+  test('warns when loudness is outside tolerance', () => {
+    const plan = buildAudioMasteringPlan('/audio/narration.mp3', {
+      integratedLufs: -16.5,
+      truePeakDbtp: -2.0,
+    });
+    expect(plan.status).toBe('warn');
+    expect(plan.warnings.some((w) => w.includes('LUFS'))).toBe(true);
+  });
+
+  test('fails when true peak exceeds limit', () => {
+    const plan = buildAudioMasteringPlan('/audio/narration.mp3', {
+      integratedLufs: -14.0,
+      truePeakDbtp: -0.3,
+    });
+    expect(plan.status).toBe('fail');
+    expect(plan.warnings.some((w) => w.includes('True peak'))).toBe(true);
+  });
+
+  test('fails when clipping is detected', () => {
+    const plan = buildAudioMasteringPlan('/audio/narration.mp3', {
+      integratedLufs: -14.0,
+      truePeakDbtp: -1.5,
+      maxPeakDbfs: 0.0,
+    });
+    expect(plan.status).toBe('fail');
+    expect(plan.warnings.some((w) => w.includes('Clipping'))).toBe(true);
+  });
+
+  test('warns on long silence segments', () => {
+    const plan = buildAudioMasteringPlan('/audio/narration.mp3', {
+      integratedLufs: -14.0,
+      truePeakDbtp: -1.5,
+      silenceSegments: [{ startMs: 1000, endMs: 8000 }],
+    });
+    expect(plan.warnings.some((w) => w.includes('Silence'))).toBe(true);
+  });
+
+  test('warns when no analyzer data is available', () => {
+    const plan = buildAudioMasteringPlan('/audio/narration.mp3', null);
+    expect(plan.status).toBe('warn');
+    expect(plan.analyzerStatus).toBe('missing');
+    expect(plan.warnings.some((w) => w.includes('No analyzer data'))).toBe(true);
+  });
+
+  test('disables when no input path provided', () => {
+    const plan = buildAudioMasteringPlan(null);
+    expect(plan.enabled).toBe(false);
+    expect(plan.status).toBe('disabled');
+  });
+
+  test('supports custom thresholds', () => {
+    const plan = buildAudioMasteringPlan('/audio/narration.mp3', {
+      integratedLufs: -16.0,
+      truePeakDbtp: -1.5,
+    }, { targets: { targetIntegratedLufs: -16, lufsTolerance: 0.5 } });
+    expect(plan.status).toBe('pass');
+  });
+
+  test('dry-run FFmpeg args include loudnorm filter', () => {
+    const plan = buildAudioMasteringPlan('/audio/narration.mp3', {
+      integratedLufs: -14.0,
+      truePeakDbtp: -1.5,
+    });
+    expect(plan.ffmpegArgs).toContain('-af');
+    const afIdx = plan.ffmpegArgs.indexOf('-af');
+    expect(plan.ffmpegArgs[afIdx + 1]).toContain('loudnorm');
+    expect(plan.ffmpegArgs[afIdx + 1]).toContain('I=-14');
+    expect(plan.ffmpegArgs[afIdx + 1]).toContain('TP=-1');
+  });
+
+  test('output naming uses -mastered suffix', () => {
+    const plan = buildAudioMasteringPlan('/out/narration.mp3', { integratedLufs: -14 });
+    expect(plan.outputAudioPath).toContain('narration-mastered.m4a');
+  });
+
+  test('includes ducking preparation metadata', () => {
+    const plan = buildAudioMasteringPlan('/audio/x.mp3', { integratedLufs: -14, truePeakDbtp: -2 });
+    expect(plan.duckingPreparation).toBeDefined();
+    expect(plan.duckingPreparation.narrationPriority).toBe(true);
+    expect(plan.duckingPreparation.musicBedSupported).toBe(false);
+    expect(plan.duckingPreparation.recommendedMusicDuckDb).toBe(18);
+  });
+
+  test('default targets match MOBIUS Elite standards', () => {
+    expect(DEFAULT_MASTERING_TARGETS.targetIntegratedLufs).toBe(-14);
+    expect(DEFAULT_MASTERING_TARGETS.truePeakLimitDbtp).toBe(-1.0);
+    expect(DEFAULT_MASTERING_TARGETS.clippingLimitDbfs).toBe(0.0);
+    expect(DEFAULT_MASTERING_TARGETS.sampleRate).toBe(48000);
+  });
+});


### PR DESCRIPTION
## Summary

Deterministic audio mastering plan generation with loudness normalization, true-peak limiting, clipping detection, silence validation, and ducking preparation metadata.

### Module: src/services/audioMasteringPlan.js

- buildAudioMasteringPlan(inputAudioPath, analyzerResult, options)
- Validates against MOBIUS Elite thresholds: -14 LUFS ±0.5, TP ≤ -1.0 dBTP, clipping ≥ 0 dBFS
- Generates FFmpeg loudnorm filter args for normalization
- Reports: pass/warn/fail status, clipping, silence, missing analyzer data
- Includes ducking preparation metadata (future-ready, music not yet supported)
- Supports custom thresholds and dry-run mode

### Tests (12 new)

- Pass when within targets
- Warn on loudness outside tolerance
- Fail on true peak, clipping
- Long silence warning
- Missing analyzer data advisory
- Disabled without input
- Custom thresholds
- FFmpeg loudnorm args validation
- Output naming convention
- Ducking metadata
- Default threshold values

### Stack

- PR #411 → main (FFmpeg muxing plan)
- This PR → PR #411 (mastering foundation)

All 37 suites, 305 tests pass (304 passed, 1 skipped), zero failures.