### PR TITLE
ci: add Node 22 real pdfjs-dist PDF extraction validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,3 +430,26 @@ jobs:
             out/mobius-e2e/**
           retention-days: 7
 
+
+  pdfjs-dist-node22:
+    name: Node 22 – Real pdfjs-dist PDF Extraction
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Node 22 real pdfjs-dist extraction test
+        env:
+          MOBIUS_ENABLE_PDFJS_DIST_REAL_TEST: '1'
+        run: npx jest --ci --forceExit --testPathPattern="pdfExtractor.node22"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test-pipeline": "npm run compile-shotlist && npm run verify && npm run bind-alignment",
     "test": "jest --testPathIgnorePatterns='/eliteVerifierSkeleton\\.test\\.mjs$'",
     "test:elite": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config jest.config.elite.mjs",
+    "test:pdfjs-node22": "MOBIUS_ENABLE_PDFJS_DIST_REAL_TEST=1 jest --ci --forceExit --testPathPattern=pdfExtractor.node22",
     "gen:shotlists": "node scripts/compile-shotlist.mjs gigs/hanamikoji.json > tmp/shotlist.json",
     "gen:timelines": "echo 'Generating timelines...'",
     "render:proxy": "node scripts/render-ffmpeg.mjs tmp/timeline.json assets out/preview.mp4 --preview",

--- a/tests/ingestion/pdfExtractor.node22.test.js
+++ b/tests/ingestion/pdfExtractor.node22.test.js
@@ -1,0 +1,175 @@
+/**
+ * Node 22+ real pdfjs-dist extraction validation.
+ *
+ * This test file validates that the direct pdfjs-dist engine activates on
+ * Node 22+ and correctly extracts structured blocks from a real PDF generated
+ * at test time via pdf-lib. It is gated by:
+ *   1. Node.js major version >= 22
+ *   2. Environment variable MOBIUS_ENABLE_PDFJS_DIST_REAL_TEST=1
+ *
+ * On Node 18/20 or without the env flag, all tests are skipped.
+ */
+
+const nodeVersion = parseInt(process.versions.node.split('.')[0], 10);
+const envEnabled = process.env.MOBIUS_ENABLE_PDFJS_DIST_REAL_TEST === '1';
+const shouldRun = nodeVersion >= 22 && envEnabled;
+
+const describeIfNode22 = shouldRun ? describe : describe.skip;
+
+describeIfNode22('pdfExtractor – Node 22 real pdfjs-dist extraction', () => {
+  const path = require('path');
+  const fs = require('fs');
+  const os = require('os');
+  const { extractPdfToIngestionInput, detectPdfjsDistCapability } = require('../../src/ingestion/pdfExtractor');
+
+  let tempDir;
+  let pdfPath;
+
+  beforeAll(async () => {
+    // Generate a modern PDF using pdf-lib (available in project deps)
+    const { PDFDocument, StandardFonts } = require('pdf-lib');
+
+    const doc = await PDFDocument.create();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+    const fontBold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+    const page = doc.addPage([612, 792]);
+    page.drawText('Game Setup', { x: 72, y: 720, size: 24, font: fontBold });
+    page.drawText('Place all tokens on the board.', { x: 72, y: 680, size: 12, font });
+    page.drawText('Gameplay', { x: 72, y: 620, size: 24, font: fontBold });
+    page.drawText('Players take turns clockwise.', { x: 72, y: 580, size: 12, font });
+
+    const page2 = doc.addPage([612, 792]);
+    page2.drawText('Scoring', { x: 72, y: 720, size: 24, font: fontBold });
+    page2.drawText('Count victory points at game end.', { x: 72, y: 680, size: 12, font });
+
+    const pdfBytes = await doc.save();
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mobius-pdf-test-'));
+    pdfPath = path.join(tempDir, 'test-game-rules.pdf');
+    fs.writeFileSync(pdfPath, Buffer.from(pdfBytes));
+  });
+
+  afterAll(() => {
+    // Cleanup temp files
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('capability detection reports supported on Node 22+', () => {
+    const cap = detectPdfjsDistCapability();
+    expect(cap.supported).toBe(true);
+    expect(cap.nodeVersion).toBeGreaterThanOrEqual(22);
+  });
+
+  it('auto engine selects pdfjs-dist on Node 22+', async () => {
+    const result = await extractPdfToIngestionInput(pdfPath, { engine: 'auto' });
+
+    expect(result.metadata.extractionEngine).toBe('pdfjs-dist');
+    expect(result.metadata.runtime.pdfjsDistSupported).toBe(true);
+    expect(result.metadata.runtime.nodeVersion).toMatch(/^22\./);
+  });
+
+  it('extracts structured pages from generated PDF', async () => {
+    const result = await extractPdfToIngestionInput(pdfPath);
+
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0].number).toBe(1);
+    expect(result.pages[1].number).toBe(2);
+
+    // Page 1 should have blocks with expected text
+    const page1Blocks = result.pages[0].blocks;
+    expect(page1Blocks.length).toBeGreaterThanOrEqual(2);
+
+    const texts = page1Blocks.map((b) => b.text);
+    expect(texts.some((t) => t.includes('Game Setup'))).toBe(true);
+    expect(texts.some((t) => t.includes('Gameplay'))).toBe(true);
+
+    // Page 2 should have scoring content
+    const page2Blocks = result.pages[1].blocks;
+    expect(page2Blocks.length).toBeGreaterThanOrEqual(1);
+    const page2Texts = page2Blocks.map((b) => b.text);
+    expect(page2Texts.some((t) => t.includes('Scoring'))).toBe(true);
+  });
+
+  it('blocks have valid numeric coordinates and fontSize', async () => {
+    const result = await extractPdfToIngestionInput(pdfPath);
+
+    for (const page of result.pages) {
+      for (const block of page.blocks) {
+        expect(typeof block.text).toBe('string');
+        expect(block.text.length).toBeGreaterThan(0);
+        expect(typeof block.fontSize).toBe('number');
+        expect(block.fontSize).toBeGreaterThan(0);
+        expect(typeof block.x).toBe('number');
+        expect(typeof block.y).toBe('number');
+        expect(typeof block.width).toBe('number');
+        expect(block.width).toBeGreaterThan(0);
+        expect(typeof block.height).toBe('number');
+        expect(block.height).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('heading blocks have fontSize >= 24', async () => {
+    const result = await extractPdfToIngestionInput(pdfPath);
+
+    const headingBlocks = result.pages
+      .flatMap((p) => p.blocks)
+      .filter((b) => ['Game Setup', 'Gameplay', 'Scoring'].some((h) => b.text.includes(h)));
+
+    expect(headingBlocks.length).toBeGreaterThanOrEqual(3);
+    for (const block of headingBlocks) {
+      expect(block.fontSize).toBeGreaterThanOrEqual(24);
+    }
+  });
+
+  it('produces deterministic output for the same PDF', async () => {
+    const result1 = await extractPdfToIngestionInput(pdfPath);
+    const result2 = await extractPdfToIngestionInput(pdfPath);
+
+    expect(result1.pages).toEqual(result2.pages);
+    expect(result1.ocr).toEqual(result2.ocr);
+    expect(result1.metadata.sha256).toBe(result2.metadata.sha256);
+  });
+
+  it('output is compatible with runIngestionPipeline', async () => {
+    const { runIngestionPipeline } = require('../../src/ingestion/pipeline');
+    const result = await extractPdfToIngestionInput(pdfPath);
+
+    const manifest = runIngestionPipeline({
+      documentId: 'node22-real-test',
+      metadata: { title: 'Test Game', gameId: 'test-game', source: 'test-game-rules.pdf' },
+      pages: result.pages,
+      ocr: result.ocr
+    });
+
+    expect(manifest).toHaveProperty('version');
+    expect(manifest).toHaveProperty('outline');
+    expect(manifest).toHaveProperty('components');
+    expect(manifest.outline.length).toBeGreaterThanOrEqual(3); // Game Setup, Gameplay, Scoring
+    expect(manifest.stats.pageCount).toBe(2);
+  });
+
+  it('metadata includes correct engine and version info', async () => {
+    const result = await extractPdfToIngestionInput(pdfPath);
+
+    expect(result.metadata.engine).toBe('mobius-pdf-extractor');
+    expect(result.metadata.engineVersion).toBe('2.0.0');
+    expect(result.metadata.extractionEngine).toBe('pdfjs-dist');
+    expect(result.metadata.source).toBe('test-game-rules.pdf');
+    expect(typeof result.metadata.sha256).toBe('string');
+    expect(result.metadata.sha256.length).toBe(64);
+    expect(result.metadata.pageCount).toBe(2);
+  });
+
+  it('no OCR flags on text-based PDF', async () => {
+    const result = await extractPdfToIngestionInput(pdfPath);
+
+    expect(result.ocr).toEqual({});
+    // No EMPTY_PAGE diagnostics expected
+    const emptyPageDiags = result.diagnostics.filter((d) => d.type === 'EMPTY_PAGE');
+    expect(emptyPageDiags).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Node 22-only CI job that validates real pdfjs-dist PDF extraction against a dynamically generated modern PDF. Proves the auto engine correctly selects pdfjs-dist on Node 22 and extracts structured blocks with coordinates, font sizes, and page numbers.

## Changes

- **`.github/workflows/ci.yml`** — Added `pdfjs-dist-node22` job: installs Node 22, sets `MOBIUS_ENABLE_PDFJS_DIST_REAL_TEST=1`, runs focused extraction test.
- **`tests/ingestion/pdfExtractor.node22.test.js`** (new) — 9 gated tests that:
  - Generate a 2-page PDF via pdf-lib at test time (no committed binary)
  - Verify auto engine selects pdfjs-dist on Node 22
  - Validate structured block extraction (text, fontSize, coordinates)
  - Confirm pipeline compatibility via `runIngestionPipeline`
  - Assert deterministic output and correct metadata
  - Verify no false OCR flags on text PDFs
- **`package.json`** — Added `test:pdfjs-node22` convenience script.

## Gating

Tests are double-gated and safely skip on Node 18/20:
1. `process.versions.node` major must be >= 22
2. `MOBIUS_ENABLE_PDFJS_DIST_REAL_TEST` env var must be `1`

## Local Validation (Node 20)

- Targeted ingestion: 5 suites total, **1 skipped** (Node 22), 4 passed, 54 tests passed, 0 failures
- Full non-Elite: 39 suites total, **1 skipped** (Node 22), 38 passed, 352 tests passed, 10 skipped, 0 failures

## Node 22 CI

The `pdfjs-dist-node22` job will exercise real extraction on GitHub Actions (ubuntu-latest + Node 22). Result pending first CI run on this PR.
