### PR TITLE
feat: first visible tutorial video vertical slice

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "ingestion:validate": "node scripts/check_ingestion.cjs",
     "storyboard:check": "node scripts/check_storyboard.cjs",
     "checklist:validate": "node scripts/validate_mobius_checklist.cjs",
-    "mobius:e2e": "node scripts/run_mobius_e2e.cjs --game hanamikoji --lang en --resolution 1920x1080 --mode preview"
+    "mobius:e2e": "node scripts/run_mobius_e2e.cjs --game hanamikoji --lang en --resolution 1920x1080 --mode preview",
+    "demo:tutorial-preview": "node scripts/generate-tutorial-preview.js"
   },
   "keywords": [
     "game",

--- a/scripts/generate-tutorial-preview.js
+++ b/scripts/generate-tutorial-preview.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+/**
+ * generate-tutorial-preview.js — First visible tutorial video vertical slice.
+ *
+ * Generates a complete tutorial preview pipeline from fixture data:
+ *   fixture → script → storyboard → captions/SRT → render config
+ *
+ * Usage:
+ *   node scripts/generate-tutorial-preview.js
+ *   node scripts/generate-tutorial-preview.js --fixture tests/fixtures/tutorial-vertical-slice/gem-collectors.json
+ *   node scripts/generate-tutorial-preview.js --out out/tutorial-preview
+ *   node scripts/generate-tutorial-preview.js --render  (attempts FFmpeg render if available)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { generateTutorialScript } = require('../src/services/tutorialScriptGenerator');
+const { generateStoryboardFromIngestion } = require('../src/storyboard/storyboard_from_ingestion');
+const { generateSrtContent, getSrtMetadata } = require('../src/services/srtWriter');
+const { generateCaptionCues } = require('../src/services/captionTiming');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const hasFlag = (name) => args.includes(`--${name}`);
+
+const fixturePath = getArg('fixture') || path.join(__dirname, '../tests/fixtures/tutorial-vertical-slice/gem-collectors.json');
+const outDir = getArg('out') || path.join(__dirname, '../out/tutorial-preview');
+const doRender = hasFlag('render');
+
+// ---------------------------------------------------------------------------
+// Load fixture
+// ---------------------------------------------------------------------------
+if (!fs.existsSync(fixturePath)) {
+  console.error(`Fixture not found: ${fixturePath}`);
+  process.exit(1);
+}
+
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
+console.log(`[1/6] Loaded fixture: ${fixture.gameName} (${fixture.gameId})`);
+
+// ---------------------------------------------------------------------------
+// Generate tutorial script
+// ---------------------------------------------------------------------------
+const { segments, warnings, metadata: scriptMeta } = generateTutorialScript(fixture);
+console.log(`[2/6] Generated script: ${segments.length} segments, ${scriptMeta.totalDurationSec}s total`);
+if (warnings.length) {
+  console.log(`  Warnings: ${warnings.join('; ')}`);
+}
+
+// ---------------------------------------------------------------------------
+// Convert to storyboard
+// ---------------------------------------------------------------------------
+const ingestionForStoryboard = {
+  game: { slug: fixture.gameId, name: fixture.gameName },
+  structure: {
+    setupSteps: segments.map((seg, i) => ({
+      id: seg.id,
+      order: i,
+      text: seg.narration,
+      componentRefs: []
+    }))
+  }
+};
+
+const storyboard = generateStoryboardFromIngestion(ingestionForStoryboard, {
+  width: 1920,
+  height: 1080,
+  fps: 30
+});
+console.log(`[3/6] Generated storyboard: ${storyboard.scenes.length} scenes`);
+
+// ---------------------------------------------------------------------------
+// Generate captions
+// ---------------------------------------------------------------------------
+const scenesWithNarration = storyboard.scenes.map((scene, i) => ({
+  ...scene,
+  narration: segments[i] ? segments[i].narration : ''
+}));
+
+const { cues, warnings: captionWarnings } = generateCaptionCues(scenesWithNarration, { language: 'en' });
+const srtContent = generateSrtContent(cues);
+const srtMeta = getSrtMetadata(cues);
+console.log(`[4/6] Generated captions: ${srtMeta.cueCount} cues, ${Math.round(srtMeta.totalDurationMs / 1000)}s`);
+
+// ---------------------------------------------------------------------------
+// Generate render config
+// ---------------------------------------------------------------------------
+const renderConfig = {
+  projectId: fixture.gameId,
+  video: { resolution: { width: 1920, height: 1080 }, fps: 30 },
+  scenes: segments.map((seg) => ({
+    id: seg.id,
+    durationSec: seg.durationSec,
+    background: { color: seg.type === 'hook' || seg.type === 'end_card' ? '#1a1a2e' : '#2d2d44' },
+    overlays: [
+      { type: seg.type === 'hook' || seg.type === 'end_card' ? 'title' : 'body', text: seg.narration, position: 'center' }
+    ]
+  }))
+};
+console.log(`[5/6] Generated render config: ${renderConfig.scenes.length} scenes`);
+
+// ---------------------------------------------------------------------------
+// Write outputs
+// ---------------------------------------------------------------------------
+fs.mkdirSync(outDir, { recursive: true });
+
+const outputs = {
+  script: path.join(outDir, 'script.json'),
+  storyboard: path.join(outDir, 'storyboard.json'),
+  captions: path.join(outDir, 'captions.srt'),
+  renderConfig: path.join(outDir, 'render-config.json'),
+  manifest: path.join(outDir, 'manifest.json')
+};
+
+fs.writeFileSync(outputs.script, JSON.stringify({ segments, warnings, metadata: scriptMeta }, null, 2));
+fs.writeFileSync(outputs.storyboard, JSON.stringify(storyboard, null, 2));
+fs.writeFileSync(outputs.captions, srtContent);
+fs.writeFileSync(outputs.renderConfig, JSON.stringify(renderConfig, null, 2));
+
+const manifest = {
+  generatedAt: new Date().toISOString(),
+  fixture: path.basename(fixturePath),
+  game: { id: fixture.gameId, name: fixture.gameName },
+  script: { segments: segments.length, totalDurationSec: scriptMeta.totalDurationSec, eliteS1Valid: scriptMeta.eliteS1Valid },
+  storyboard: { scenes: storyboard.scenes.length },
+  captions: { cues: srtMeta.cueCount, totalDurationMs: srtMeta.totalDurationMs },
+  render: { scenes: renderConfig.scenes.length, mode: doRender ? 'render' : 'dry-run' },
+  outputs: Object.fromEntries(Object.entries(outputs).map(([k, v]) => [k, path.relative(process.cwd(), v)])),
+  warnings
+};
+
+fs.writeFileSync(outputs.manifest, JSON.stringify(manifest, null, 2));
+
+console.log(`[6/6] Wrote artifacts to ${outDir}/`);
+console.log(`  - script.json (${segments.length} segments)`);
+console.log(`  - storyboard.json (${storyboard.scenes.length} scenes)`);
+console.log(`  - captions.srt (${srtMeta.cueCount} cues)`);
+console.log(`  - render-config.json (ready for render-storyboard-ffmpeg.mjs)`);
+console.log(`  - manifest.json (pipeline summary)`);
+
+if (doRender) {
+  console.log('\n[RENDER] Attempting FFmpeg render...');
+  console.log(`  Run: node scripts/render-storyboard-ffmpeg.mjs --config ${outputs.renderConfig} --out out/tutorial-preview/preview.mp4`);
+  try {
+    const { execFileSync } = require('child_process');
+    execFileSync('node', [
+      path.join(__dirname, 'render-storyboard-ffmpeg.mjs'),
+      '--config', outputs.renderConfig,
+      '--out', path.join(outDir, 'preview.mp4')
+    ], { stdio: 'inherit' });
+  } catch (err) {
+    console.warn('[RENDER] FFmpeg render skipped or failed. Artifacts are still valid for manual render.');
+  }
+} else {
+  console.log('\n[DRY RUN] Render skipped. Use --render to attempt FFmpeg output.');
+  console.log(`  Manual: node scripts/render-storyboard-ffmpeg.mjs --config ${path.relative(process.cwd(), outputs.renderConfig)} --out out/tutorial-preview/preview.mp4`);
+}
+
+console.log('\n✓ Tutorial vertical slice complete.');

--- a/src/services/tutorialScriptGenerator.js
+++ b/src/services/tutorialScriptGenerator.js
@@ -1,0 +1,151 @@
+/**
+ * Deterministic tutorial script generator for MOBIUS vertical slice.
+ *
+ * Converts a game fixture into beginner-first script segments following
+ * the Elite Video Standard S1 ordering. No LLM calls, no network access.
+ * All narration is derived directly from fixture data with source references.
+ */
+
+const { computeTextDuration } = require('../storyboard/storyboard_timing');
+const { SEGMENT_TYPES, ELITE_S1_REQUIRED_ORDER, validateSegment, validateEliteOrdering } = require('./tutorialScriptSchema');
+
+/**
+ * Generate a deterministic tutorial script from a game fixture.
+ *
+ * @param {object} fixture - Game fixture data (see tests/fixtures/tutorial-vertical-slice/)
+ * @returns {{ segments: Array, warnings: string[], metadata: object }}
+ */
+function generateTutorialScript(fixture) {
+  if (!fixture || typeof fixture !== 'object') {
+    throw new Error('SCRIPT_GENERATION_FAILED: fixture is required');
+  }
+
+  const segments = [];
+  const warnings = [];
+  const gameName = fixture.gameName || 'Unknown Game';
+  const gameId = fixture.gameId || 'unknown';
+
+  // --- Hook (0-10s) ---
+  const hookText = `After this video, you'll know how to play ${gameName} and score your first game.`;
+  segments.push(makeSegment('hook', hookText, { sourceField: 'gameName' }));
+
+  // --- Game Identity ---
+  const playerRange = fixture.playerCount
+    ? `${fixture.playerCount.min}–${fixture.playerCount.max} players`
+    : null;
+  const identityParts = [`Game: ${gameName}`];
+  if (playerRange) identityParts.push(`Players: ${playerRange}`);
+  if (fixture.duration) identityParts.push(`Duration: ${fixture.duration}`);
+  const identityText = identityParts.join('. ') + '.';
+  segments.push(makeSegment('game_identity', identityText, { sourceField: 'playerCount,duration' }));
+
+  // --- Objective (Elite S1 required) ---
+  if (fixture.objective) {
+    segments.push(makeSegment('objective', fixture.objective, { sourceField: 'objective' }));
+  } else {
+    warnings.push('Missing fixture.objective — segment skipped');
+  }
+
+  // --- Components (optional) ---
+  if (Array.isArray(fixture.components) && fixture.components.length > 0) {
+    const compText = 'You will need: ' + fixture.components
+      .map((c) => `${c.quantity} ${c.name}`)
+      .join(', ') + '.';
+    segments.push(makeSegment('components', compText, { sourceField: 'components' }));
+  }
+
+  // --- Setup (optional) ---
+  if (Array.isArray(fixture.setup) && fixture.setup.length > 0) {
+    const setupText = fixture.setup
+      .map((step, i) => `Step ${i + 1}: ${step}`)
+      .join(' ');
+    segments.push(makeSegment('setup', setupText, { sourceField: 'setup' }));
+  }
+
+  // --- Turn Structure (Elite S1 required) ---
+  if (fixture.turnStructure) {
+    let turnText = fixture.turnStructure.description || '';
+    if (fixture.turnStructure.phases && fixture.turnStructure.phases.length) {
+      turnText += ` Each turn has ${fixture.turnStructure.phases.length} phases: ${fixture.turnStructure.phases.join(', ')}.`;
+    }
+    if (fixture.turnStructure.endCondition) {
+      turnText += ` ${fixture.turnStructure.endCondition}`;
+    }
+    segments.push(makeSegment('turn_structure', turnText.trim(), { sourceField: 'turnStructure' }));
+  } else {
+    warnings.push('Missing fixture.turnStructure — segment skipped');
+  }
+
+  // --- Core Mechanic (Elite S1 required) ---
+  if (fixture.coreMechanic) {
+    let mechText = fixture.coreMechanic.description || '';
+    if (fixture.coreMechanic.name) {
+      mechText = `The core mechanic is ${fixture.coreMechanic.name}. ${mechText}`;
+    }
+    segments.push(makeSegment('core_mechanic', mechText.trim(), { sourceField: 'coreMechanic' }));
+  } else {
+    warnings.push('Missing fixture.coreMechanic — segment skipped');
+  }
+
+  // --- Scoring (Elite S1 required) ---
+  if (fixture.scoring) {
+    let scoreText = fixture.scoring.description || '';
+    if (fixture.scoring.winCondition) {
+      scoreText += ` ${fixture.scoring.winCondition}`;
+    }
+    segments.push(makeSegment('scoring', scoreText.trim(), { sourceField: 'scoring' }));
+  } else {
+    warnings.push('Missing fixture.scoring — segment skipped');
+  }
+
+  // --- Edge Cases (Elite S1 required) ---
+  if (Array.isArray(fixture.edgeCases) && fixture.edgeCases.length > 0) {
+    const edgeText = 'A few things to watch out for: ' + fixture.edgeCases.join(' ');
+    segments.push(makeSegment('edge_cases', edgeText, { sourceField: 'edgeCases' }));
+  } else {
+    warnings.push('Missing fixture.edgeCases — segment skipped');
+  }
+
+  // --- Recap ---
+  const recapText = `That's everything you need to start playing ${gameName}. Remember: ${fixture.objective || 'have fun!'}`;
+  segments.push(makeSegment('recap', recapText, { sourceField: 'objective' }));
+
+  // --- End Card ---
+  segments.push(makeSegment('end_card', `You're ready to play ${gameName}!`, { sourceField: 'gameName' }));
+
+  // Validate Elite ordering
+  const orderingResult = validateEliteOrdering(segments);
+  if (!orderingResult.valid) {
+    warnings.push(...orderingResult.errors);
+  }
+
+  const totalDurationSec = segments.reduce((sum, s) => sum + s.durationSec, 0);
+
+  const metadata = {
+    gameId,
+    gameName,
+    segmentCount: segments.length,
+    totalDurationSec: Math.round(totalDurationSec * 100) / 100,
+    eliteS1Valid: orderingResult.valid,
+    generatedBy: 'mobius-tutorial-script-generator',
+    version: '1.0.0'
+  };
+
+  return { segments, warnings, metadata };
+}
+
+function makeSegment(type, narration, options = {}) {
+  const durationSec = computeTextDuration(narration);
+  return {
+    id: `segment-${type}`,
+    type,
+    narration,
+    durationSec,
+    sourceRef: options.sourceField || null,
+    confidence: 1.0
+  };
+}
+
+module.exports = {
+  generateTutorialScript
+};

--- a/src/services/tutorialScriptSchema.js
+++ b/src/services/tutorialScriptSchema.js
@@ -1,0 +1,81 @@
+/**
+ * Tutorial script segment schema and types for MOBIUS vertical slice.
+ *
+ * Follows the Elite Video Standard S1 required ordering:
+ *   objective → turn_structure → core_mechanic → scoring → edge_cases
+ * Plus optional segments: hook, game_identity, components, setup, recap, end_card
+ */
+
+const SEGMENT_TYPES = [
+  'hook',
+  'game_identity',
+  'objective',
+  'components',
+  'setup',
+  'turn_structure',
+  'core_mechanic',
+  'scoring',
+  'edge_cases',
+  'recap',
+  'end_card'
+];
+
+// Elite S1 required ordering (these must appear in this order)
+const ELITE_S1_REQUIRED_ORDER = [
+  'objective',
+  'turn_structure',
+  'core_mechanic',
+  'scoring',
+  'edge_cases'
+];
+
+/**
+ * Validate a script segment shape.
+ * @param {object} segment
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateSegment(segment) {
+  const errors = [];
+  if (!segment) { errors.push('Segment is null/undefined'); return { valid: false, errors }; }
+  if (!segment.id) errors.push('Missing segment.id');
+  if (!segment.type || !SEGMENT_TYPES.includes(segment.type)) {
+    errors.push(`Invalid segment type: ${segment.type}`);
+  }
+  if (!segment.narration || typeof segment.narration !== 'string') {
+    errors.push('Missing or invalid segment.narration');
+  }
+  if (typeof segment.durationSec !== 'number' || segment.durationSec <= 0) {
+    errors.push('Invalid segment.durationSec');
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate Elite S1 ordering in a script.
+ * @param {Array} segments
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateEliteOrdering(segments) {
+  const errors = [];
+  const requiredPresent = segments
+    .filter((s) => ELITE_S1_REQUIRED_ORDER.includes(s.type))
+    .map((s) => s.type);
+
+  let lastIdx = -1;
+  for (const type of requiredPresent) {
+    const orderIdx = ELITE_S1_REQUIRED_ORDER.indexOf(type);
+    if (orderIdx < lastIdx) {
+      errors.push(`Elite S1 ordering violated: ${type} appears after a later-ordered segment`);
+    }
+    lastIdx = Math.max(lastIdx, orderIdx);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+module.exports = {
+  SEGMENT_TYPES,
+  ELITE_S1_REQUIRED_ORDER,
+  validateSegment,
+  validateEliteOrdering
+};

--- a/tests/e2e/tutorial_vertical_slice.test.js
+++ b/tests/e2e/tutorial_vertical_slice.test.js
@@ -1,0 +1,146 @@
+const path = require('path');
+const fs = require('fs');
+const { generateTutorialScript } = require('../../src/services/tutorialScriptGenerator');
+const { generateStoryboardFromIngestion } = require('../../src/storyboard/storyboard_from_ingestion');
+const { validateStoryboard } = require('../../src/validators/storyboardValidator');
+const { generateCaptionCues, validateCaptionCues } = require('../../src/services/captionTiming');
+const { generateSrtContent, getSrtMetadata } = require('../../src/services/srtWriter');
+
+const fixturePath = path.join(__dirname, '../fixtures/tutorial-vertical-slice/gem-collectors.json');
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
+
+describe('Tutorial Vertical Slice – E2E Pipeline', () => {
+  let script, storyboard, captionResult, srtContent;
+
+  beforeAll(() => {
+    // Step 1: Generate script from fixture
+    script = generateTutorialScript(fixture);
+
+    // Step 2: Convert script to storyboard
+    const ingestionForStoryboard = {
+      game: { slug: fixture.gameId, name: fixture.gameName },
+      structure: {
+        setupSteps: script.segments.map((seg, i) => ({
+          id: seg.id,
+          order: i,
+          text: seg.narration,
+          componentRefs: []
+        }))
+      }
+    };
+    storyboard = generateStoryboardFromIngestion(ingestionForStoryboard, {
+      width: 1920, height: 1080, fps: 30
+    });
+
+    // Step 3: Generate captions
+    const scenesWithNarration = storyboard.scenes.map((scene, i) => ({
+      ...scene,
+      narration: script.segments[i] ? script.segments[i].narration : ''
+    }));
+    captionResult = generateCaptionCues(scenesWithNarration, { language: 'en' });
+
+    // Step 4: Generate SRT
+    srtContent = generateSrtContent(captionResult.cues);
+  });
+
+  describe('Script Generation', () => {
+    it('produces valid segments from fixture', () => {
+      expect(script.segments.length).toBeGreaterThan(5);
+      expect(script.metadata.eliteS1Valid).toBe(true);
+    });
+
+    it('total duration is within target range', () => {
+      expect(script.metadata.totalDurationSec).toBeGreaterThan(30);
+      expect(script.metadata.totalDurationSec).toBeLessThan(120);
+    });
+  });
+
+  describe('Storyboard Generation', () => {
+    it('produces scenes from script segments', () => {
+      // intro + segments + end_card
+      expect(storyboard.scenes.length).toBe(script.segments.length + 2);
+    });
+
+    it('storyboard has correct game metadata', () => {
+      expect(storyboard.game.slug).toBe('gem-collectors');
+      expect(storyboard.game.name).toBe('Gem Collectors');
+    });
+
+    it('storyboard passes contract validation', () => {
+      const { valid, errors } = validateStoryboard(storyboard, { contractVersion: '1.1.0' });
+      expect({ valid, errors }).toEqual({ valid: true, errors: [] });
+    });
+
+    it('scenes are properly linked (prev/next)', () => {
+      for (let i = 0; i < storyboard.scenes.length; i++) {
+        const scene = storyboard.scenes[i];
+        if (i === 0) expect(scene.prevSceneId).toBeNull();
+        else expect(scene.prevSceneId).toBe(storyboard.scenes[i - 1].id);
+        if (i === storyboard.scenes.length - 1) expect(scene.nextSceneId).toBeNull();
+        else expect(scene.nextSceneId).toBe(storyboard.scenes[i + 1].id);
+      }
+    });
+
+    it('first scene is intro, last is end_card', () => {
+      expect(storyboard.scenes[0].type).toBe('intro');
+      expect(storyboard.scenes[storyboard.scenes.length - 1].type).toBe('end_card');
+    });
+  });
+
+  describe('Caption Generation', () => {
+    it('produces cues from storyboard scenes', () => {
+      expect(captionResult.cues.length).toBeGreaterThan(0);
+    });
+
+    it('cues pass timing validation', () => {
+      const { valid } = validateCaptionCues(captionResult.cues);
+      expect(valid).toBe(true);
+    });
+
+    it('total caption duration matches storyboard', () => {
+      const storyboardDurationMs = storyboard.scenes.reduce((sum, s) => sum + s.durationSec * 1000, 0);
+      // Caption duration should not exceed storyboard duration
+      expect(captionResult.totalDurationMs).toBeLessThanOrEqual(Math.ceil(storyboardDurationMs));
+    });
+  });
+
+  describe('SRT Output', () => {
+    it('produces valid SRT content', () => {
+      expect(srtContent).toBeTruthy();
+      expect(srtContent.length).toBeGreaterThan(50);
+    });
+
+    it('SRT contains proper timestamp format', () => {
+      expect(srtContent).toMatch(/\d{2}:\d{2}:\d{2},\d{3} --> \d{2}:\d{2}:\d{2},\d{3}/);
+    });
+
+    it('SRT metadata is consistent', () => {
+      const meta = getSrtMetadata(captionResult.cues);
+      expect(meta.cueCount).toBe(captionResult.cues.length);
+      expect(meta.language).toBe('en');
+    });
+  });
+
+  describe('Render Config', () => {
+    it('can produce a valid render config from script', () => {
+      const renderConfig = {
+        projectId: fixture.gameId,
+        video: { resolution: { width: 1920, height: 1080 }, fps: 30 },
+        scenes: script.segments.map((seg) => ({
+          id: seg.id,
+          durationSec: seg.durationSec,
+          background: { color: '#2d2d44' },
+          overlays: [{ type: 'body', text: seg.narration, position: 'center' }]
+        }))
+      };
+
+      expect(renderConfig.projectId).toBe('gem-collectors');
+      expect(renderConfig.scenes.length).toBe(script.segments.length);
+      renderConfig.scenes.forEach((scene) => {
+        expect(scene.durationSec).toBeGreaterThan(0);
+        expect(scene.background).toHaveProperty('color');
+        expect(scene.overlays.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});

--- a/tests/fixtures/tutorial-vertical-slice/gem-collectors.json
+++ b/tests/fixtures/tutorial-vertical-slice/gem-collectors.json
@@ -1,0 +1,37 @@
+{
+  "gameId": "gem-collectors",
+  "gameName": "Gem Collectors",
+  "playerCount": { "min": 2, "max": 4 },
+  "duration": "20 minutes",
+  "designer": "Synthetic Fixture (no real game)",
+  "objective": "Collect the most valuable set of gems by drafting cards from a shared market.",
+  "components": [
+    { "name": "Gem cards", "quantity": 60, "category": "cards" },
+    { "name": "Market board", "quantity": 1, "category": "board" },
+    { "name": "Score tokens", "quantity": 40, "category": "tokens" },
+    { "name": "First player marker", "quantity": 1, "category": "tokens" }
+  ],
+  "setup": [
+    "Shuffle all 60 gem cards and place them face-down as the draw pile.",
+    "Reveal 5 cards from the draw pile onto the market board.",
+    "Give each player 3 score tokens.",
+    "The youngest player takes the first player marker."
+  ],
+  "turnStructure": {
+    "phases": ["Take", "Refill"],
+    "description": "On your turn, take one card from the market, then refill the market from the draw pile.",
+    "endCondition": "The game ends when the draw pile is empty and all market cards are taken."
+  },
+  "coreMechanic": {
+    "name": "Set Collection",
+    "description": "Collect sets of matching gem colors. Each complete set of 3 same-color gems scores 5 points. Mixed pairs score 2 points each."
+  },
+  "scoring": {
+    "description": "Count your gem sets at game end. Complete sets of 3 matching gems score 5 points. Pairs of different gems score 2 points. Single gems score 0 points.",
+    "winCondition": "The player with the most points wins. Ties broken by most complete sets."
+  },
+  "edgeCases": [
+    "If the market is empty and the draw pile is depleted, the game ends immediately.",
+    "Wild gem cards count as any color but cannot form a set alone."
+  ]
+}

--- a/tests/services/tutorialScriptGenerator.test.js
+++ b/tests/services/tutorialScriptGenerator.test.js
@@ -1,0 +1,105 @@
+const path = require('path');
+const fs = require('fs');
+const { generateTutorialScript } = require('../../src/services/tutorialScriptGenerator');
+const { validateSegment, validateEliteOrdering, ELITE_S1_REQUIRED_ORDER } = require('../../src/services/tutorialScriptSchema');
+
+const fixturePath = path.join(__dirname, '../fixtures/tutorial-vertical-slice/gem-collectors.json');
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf-8'));
+
+describe('tutorialScriptGenerator', () => {
+  let result;
+
+  beforeAll(() => {
+    result = generateTutorialScript(fixture);
+  });
+
+  it('produces segments array', () => {
+    expect(Array.isArray(result.segments)).toBe(true);
+    expect(result.segments.length).toBeGreaterThan(0);
+  });
+
+  it('produces metadata with correct game info', () => {
+    expect(result.metadata.gameId).toBe('gem-collectors');
+    expect(result.metadata.gameName).toBe('Gem Collectors');
+    expect(result.metadata.generatedBy).toBe('mobius-tutorial-script-generator');
+  });
+
+  it('follows Elite S1 required ordering', () => {
+    const ordering = validateEliteOrdering(result.segments);
+    expect(ordering.valid).toBe(true);
+    expect(ordering.errors).toEqual([]);
+  });
+
+  it('includes all Elite S1 required segment types', () => {
+    const types = result.segments.map((s) => s.type);
+    for (const required of ELITE_S1_REQUIRED_ORDER) {
+      expect(types).toContain(required);
+    }
+  });
+
+  it('each segment has valid shape', () => {
+    for (const segment of result.segments) {
+      const { valid, errors } = validateSegment(segment);
+      expect({ id: segment.id, valid, errors }).toEqual({ id: segment.id, valid: true, errors: [] });
+    }
+  });
+
+  it('segments have positive durations', () => {
+    for (const segment of result.segments) {
+      expect(segment.durationSec).toBeGreaterThan(0);
+    }
+  });
+
+  it('total duration is reasonable (30-120s)', () => {
+    expect(result.metadata.totalDurationSec).toBeGreaterThan(30);
+    expect(result.metadata.totalDurationSec).toBeLessThan(120);
+  });
+
+  it('narration is derived from fixture data (no hallucinated rules)', () => {
+    for (const segment of result.segments) {
+      expect(segment.narration).toBeTruthy();
+      expect(segment.sourceRef).toBeTruthy();
+      // Narration should reference known fixture content
+      expect(typeof segment.narration).toBe('string');
+      expect(segment.narration.length).toBeGreaterThan(5);
+    }
+  });
+
+  it('hook segment mentions game name', () => {
+    const hook = result.segments.find((s) => s.type === 'hook');
+    expect(hook).toBeDefined();
+    expect(hook.narration).toContain('Gem Collectors');
+  });
+
+  it('objective segment matches fixture', () => {
+    const obj = result.segments.find((s) => s.type === 'objective');
+    expect(obj).toBeDefined();
+    expect(obj.narration).toBe(fixture.objective);
+  });
+
+  it('produces deterministic output', () => {
+    const result2 = generateTutorialScript(fixture);
+    expect(result.segments).toEqual(result2.segments);
+    expect(result.metadata.segmentCount).toBe(result2.metadata.segmentCount);
+    expect(result.metadata.totalDurationSec).toBe(result2.metadata.totalDurationSec);
+  });
+
+  it('warns on missing data instead of crashing', () => {
+    const minimal = { gameId: 'test', gameName: 'Test' };
+    const minResult = generateTutorialScript(minimal);
+    expect(minResult.segments.length).toBeGreaterThan(0);
+    expect(minResult.warnings.length).toBeGreaterThan(0);
+    expect(minResult.warnings.some((w) => w.includes('Missing'))).toBe(true);
+  });
+
+  it('throws on null/undefined fixture', () => {
+    expect(() => generateTutorialScript(null)).toThrow('SCRIPT_GENERATION_FAILED');
+    expect(() => generateTutorialScript(undefined)).toThrow('SCRIPT_GENERATION_FAILED');
+  });
+
+  it('confidence is always 1.0 (no LLM uncertainty)', () => {
+    for (const segment of result.segments) {
+      expect(segment.confidence).toBe(1.0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

First visible tutorial video vertical slice — a complete fixture-to-preview pipeline that generates a deterministic beginner-first tutorial from synthetic game data without LLM, BGG, or network calls.

## What It Does

Run `npm run demo:tutorial-preview` and get:
- `out/tutorial-preview/script.json` — 11 segments, Elite S1 ordered
- `out/tutorial-preview/storyboard.json` — governed storyboard (v1.1.0 contract)
- `out/tutorial-preview/captions.srt` — timed SRT subtitles
- `out/tutorial-preview/render-config.json` — ready for `render-storyboard-ffmpeg.mjs`
- `out/tutorial-preview/manifest.json` — pipeline summary

Optional: `npm run demo:tutorial-preview -- --render` attempts FFmpeg render.

## Architecture

```
gem-collectors.json (synthetic fixture)
        │
        ▼
tutorialScriptGenerator.js → script segments (Elite S1 ordered)
        │
        ▼
storyboard_from_ingestion.js → governed storyboard scenes
        │
        ▼
captionTiming.js + srtWriter.js → timed captions + SRT
        │
        ▼
render-config.json → ready for render-storyboard-ffmpeg.mjs
```

## New Files (7)

| File | Purpose |
|------|---------|
| `src/services/tutorialScriptGenerator.js` | Deterministic script generation from fixture |
| `src/services/tutorialScriptSchema.js` | Segment types, Elite S1 ordering validation |
| `scripts/generate-tutorial-preview.js` | CLI entry point for vertical slice |
| `tests/fixtures/tutorial-vertical-slice/gem-collectors.json` | Synthetic game fixture |
| `tests/services/tutorialScriptGenerator.test.js` | 14 unit tests |
| `tests/e2e/tutorial_vertical_slice.test.js` | 14 E2E pipeline tests |
| `package.json` | Added `demo:tutorial-preview` script |

## Validation

- New tests: 28 (14 unit + 14 E2E), all passing
- Full non-Elite suite: **40 suites, 380 passed, 1 skipped, 0 failures**
- No new dependencies added
- No generated outputs committed

## Design Decisions

- **No LLM calls** — all narration derived directly from fixture fields
- **Source references** — every segment has `sourceRef` pointing to fixture field
- **Elite S1 ordering** — validated: objective → turn_structure → core_mechanic → scoring → edge_cases
- **Deterministic** — same input always produces same output (tested)
- **Synthetic fixture** — "Gem Collectors" is entirely fictional, no copyright concerns
- **Confidence = 1.0** — no uncertainty since all data comes from controlled fixture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tutorial preview generation pipeline that converts game fixtures into structured tutorial scripts with narration segments, storyboards, captions, and render configurations.

* **Chores**
  * Added new preview generation command to development scripts.

* **Tests**
  * Added comprehensive test coverage for tutorial script generation and full preview pipeline validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->