### PR TITLE
ci: add Tutorial Preview Demo workflow for MP4 artifact

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -1,0 +1,87 @@
+name: Tutorial Preview Demo
+
+on:
+  workflow_dispatch:
+    inputs:
+      fixture:
+        description: 'Fixture file (relative to repo root)'
+        required: false
+        default: 'tests/fixtures/tutorial-vertical-slice/gem-collectors.json'
+
+jobs:
+  generate-preview:
+    name: Generate Tutorial Preview MP4
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup FFmpeg
+        uses: FedericoCarboni/setup-ffmpeg@v3
+        with:
+          ffmpeg-version: release
+          github-token: ${{ github.token }}
+
+      - name: Verify FFmpeg
+        run: |
+          ffmpeg -version | head -1
+          ffprobe -version | head -1
+
+      - name: Generate tutorial artifacts (dry-run)
+        run: node scripts/generate-tutorial-preview.mjs --fixture "${{ github.event.inputs.fixture }}"
+
+      - name: Render MP4 preview
+        run: |
+          node scripts/render-storyboard-ffmpeg.mjs \
+            --config out/tutorial-preview/render-config.json \
+            --out out/tutorial-preview/preview.mp4
+
+      - name: Verify preview.mp4 exists and is non-empty
+        run: |
+          if [ ! -s out/tutorial-preview/preview.mp4 ]; then
+            echo "ERROR: preview.mp4 is missing or empty" >&2
+            exit 1
+          fi
+          echo "preview.mp4 size: $(stat -c%s out/tutorial-preview/preview.mp4) bytes"
+
+      - name: Capture media metadata
+        run: |
+          ffprobe -hide_banner -print_format json -show_format -show_streams \
+            out/tutorial-preview/preview.mp4 > out/tutorial-preview/ffprobe.json
+          echo "### Tutorial Preview Media Info" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat out/tutorial-preview/ffprobe.json | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          summary = {
+            'duration': data.get('format', {}).get('duration'),
+            'size_bytes': data.get('format', {}).get('size'),
+            'streams': [{'type': s.get('codec_type'), 'codec': s.get('codec_name'), 'resolution': f\"{s.get('width')}x{s.get('height')}\" if s.get('width') else None} for s in data.get('streams', [])]
+          }
+          json.dump(summary, sys.stdout, indent=2)
+          " >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload tutorial preview artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobius-tutorial-preview-gem-collectors
+          path: |
+            out/tutorial-preview/preview.mp4
+            out/tutorial-preview/script.json
+            out/tutorial-preview/storyboard.json
+            out/tutorial-preview/captions.srt
+            out/tutorial-preview/render-config.json
+            out/tutorial-preview/manifest.json
+            out/tutorial-preview/ffprobe.json
+          retention-days: 30

--- a/docs/qa/FIRST_VISIBLE_TUTORIAL_VERTICAL_SLICE.md
+++ b/docs/qa/FIRST_VISIBLE_TUTORIAL_VERTICAL_SLICE.md
@@ -1,0 +1,82 @@
+# First Visible Tutorial Video – Vertical Slice
+
+## Overview
+
+The MOBIUS tutorial vertical slice generates a complete beginner-first tutorial
+preview from synthetic fixture data. The pipeline:
+
+```
+Fixture → Script → Storyboard → Captions/SRT → Render Config → MP4
+```
+
+## Quick Start
+
+### Local Dry-Run (no FFmpeg required)
+
+```bash
+npm run demo:tutorial-preview
+```
+
+Produces `out/tutorial-preview/`:
+- `script.json` — 11 segments, ~85s, Elite S1 ordered
+- `storyboard.json` — 13 scenes (v1.1.0 contract)
+- `captions.srt` — timed SRT subtitles
+- `render-config.json` — ready for FFmpeg renderer
+- `manifest.json` — pipeline summary
+
+### Local Full Render (requires FFmpeg)
+
+```bash
+npm run demo:tutorial-preview
+node scripts/render-storyboard-ffmpeg.mjs \
+  --config out/tutorial-preview/render-config.json \
+  --out out/tutorial-preview/preview.mp4
+```
+
+### CI-Generated MP4 Artifact (recommended)
+
+1. Go to **Actions** → **Tutorial Preview Demo**
+2. Click **Run workflow** (uses `workflow_dispatch`)
+3. Wait for the job to complete (~1-2 minutes)
+4. Download the `mobius-tutorial-preview-gem-collectors` artifact
+5. Extract and play `preview.mp4`
+
+## What's in the Preview
+
+| Segment | Content |
+|---------|---------|
+| Hook | "After this video, you'll know how to play Gem Collectors..." |
+| Game Identity | 2-4 players, 20 minutes |
+| Objective | Collect the most valuable set of gems by drafting cards |
+| Components | 60 gem cards, market board, score tokens, first player marker |
+| Setup | 4 steps — shuffle, reveal market, distribute tokens, assign first player |
+| Turn Structure | Take → Refill, ends when draw pile empty |
+| Core Mechanic | Set Collection: 3 matching = 5pts, mixed pairs = 2pts |
+| Scoring | Complete sets, pairs, win condition (most points, tiebreak) |
+| Edge Cases | Empty market end, wild gem card rules |
+| Recap | Summary + objective reminder |
+| End Card | "You're ready to play Gem Collectors!" |
+
+## Technical Details
+
+- **Elite S1 Ordering**: Validated (objective → turn_structure → core_mechanic → scoring → edge_cases)
+- **No LLM calls**: All narration derived directly from fixture fields
+- **Source references**: Every segment has `sourceRef` pointing to fixture field
+- **Deterministic**: Same input always produces same output
+- **Confidence**: Always 1.0 (no AI uncertainty)
+- **Game**: "Gem Collectors" — entirely synthetic/fictional, no copyright
+
+## Limitations
+
+- Visual output is text-on-color-background (no game art or animations yet)
+- No real narration audio (text only, silent audio track)
+- Single fixture game only
+- No real PDF ingestion involved (fixture bypasses extraction)
+
+## Resolution Paths for Enhancement
+
+1. Add game art/screenshots as scene backgrounds
+2. Add TTS narration audio per scene
+3. Wire real PDF ingestion → script generation
+4. Add animations and scene transitions
+5. Support multiple fixture/game configurations


### PR DESCRIPTION
Adds a manual workflow_dispatch workflow that generates the first downloadable tutorial preview MP4. Run from Actions > Tutorial Preview Demo > Run workflow. Uploads preview.mp4 + all supporting artifacts (script, storyboard, captions, render-config, manifest, ffprobe metadata) as a 30-day artifact.