### PR TITLE
fix: use apt-get for FFmpeg in tutorial preview workflow

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -27,13 +27,9 @@ jobs:
         run: npm ci
 
       - name: Setup FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
-        with:
-          ffmpeg-version: release
-          github-token: ${{ github.token }}
-
-      - name: Verify FFmpeg
         run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ffmpeg
           ffmpeg -version | head -1
           ffprobe -version | head -1
 


### PR DESCRIPTION
FedericoCarboni/setup-ffmpeg@v3 fails with AssertionError on latest johnvansickle release fetch. Switch to apt-get install ffmpeg which is reliable on ubuntu-latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to streamline FFmpeg setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->