### PR TITLE
fix(ci): harden Tutorial Preview Demo FFmpeg setup with timeout and preinstall detection

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -12,6 +12,7 @@ jobs:
   generate-preview:
     name: Generate Tutorial Preview MP4
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,10 +28,22 @@ jobs:
         run: npm ci
 
       - name: Setup FFmpeg
+        timeout-minutes: 3
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq ffmpeg
-          ffmpeg -version | head -1
+          echo "--- FFmpeg availability check ---"
+          if command -v ffmpeg &>/dev/null && command -v ffprobe &>/dev/null; then
+            echo "FFmpeg is preinstalled on this runner."
+            echo "  ffmpeg path: $(which ffmpeg)"
+            echo "  ffprobe path: $(which ffprobe)"
+          else
+            echo "FFmpeg not found; installing via apt (timeout 180s)..."
+            timeout 180 sudo apt-get update -qq || { echo "ERROR: apt-get update timed out or failed" >&2; exit 1; }
+            timeout 180 sudo apt-get install -y -qq ffmpeg || { echo "ERROR: apt-get install ffmpeg timed out or failed" >&2; exit 1; }
+            echo "  ffmpeg path: $(which ffmpeg)"
+            echo "  ffprobe path: $(which ffprobe)"
+          fi
+          echo "--- FFmpeg diagnostics ---"
+          ffmpeg -version | head -3
           ffprobe -version | head -1
 
       - name: Generate tutorial artifacts (dry-run)


### PR DESCRIPTION
## Problem Run 27771909492 of the Tutorial Preview Demo workflow hung indefinitely on the Setup FFmpeg step due to transient GitHub runner / apt mirror slowness. The workflow had no timeout protection, so it ran for 18+ minutes before manual cancellation. ## Fix - **Job-level timeout**: Added 	imeout-minutes: 15 to the generate-preview job so the entire workflow cannot run indefinitely. - **Step-level timeout**: Added 	imeout-minutes: 3 on the Setup FFmpeg step specifically. - **Preinstall detection**: Check whether fmpeg and fprobe are already available on the runner (ubuntu-latest ships them preinstalled). Skip apt install entirely when possible. - **Shell-level timeout**: Wrap pt-get update and pt-get install in 	imeout 180 so they fail fast if the package mirror is unresponsive. - **Diagnostics**: Log binary paths and version info regardless of install method. ## Changed files - \.github/workflows/tutorial-preview-demo.yml\ ## Validation - Local Jest: 40 suites, 381 tests, 380 passed, 1 skipped, 0 failed (baseline preserved) - Previous successful run (27773018715) confirms the workflow produces valid artifacts on the same main commit - Workflow remains manual-only via workflow_dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build workflow reliability and diagnostics by adding timeout configuration to prevent long-running jobs and implementing conditional FFmpeg setup verification with improved error handling and diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->