### PR TITLE
fix(ci): increase FFmpeg setup step timeout to 7min

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
 
       - name: Setup FFmpeg
-        timeout-minutes: 3
+        timeout-minutes: 7
         run: |
           echo "--- FFmpeg availability check ---"
           if command -v ffmpeg &>/dev/null && command -v ffprobe &>/dev/null; then
@@ -36,7 +36,7 @@ jobs:
             echo "  ffmpeg path: $(which ffmpeg)"
             echo "  ffprobe path: $(which ffprobe)"
           else
-            echo "FFmpeg not found; installing via apt (timeout 180s)..."
+            echo "FFmpeg not found; installing via apt (timeout 180s per command)..."
             timeout 180 sudo apt-get update -qq || { echo "ERROR: apt-get update timed out or failed" >&2; exit 1; }
             timeout 180 sudo apt-get install -y -qq ffmpeg || { echo "ERROR: apt-get install ffmpeg timed out or failed" >&2; exit 1; }
             echo "  ffmpeg path: $(which ffmpeg)"


### PR DESCRIPTION
## Problem The hardened Tutorial Preview Demo workflow (PR #423) used a 3-minute step timeout for Setup FFmpeg. When the runner does not have FFmpeg preinstalled, the apt fallback needs up to 2x180s (for update + install). The 3-minute timeout killed the step before apt could complete. Run 27775167500 confirmed: the preinstall check correctly detected FFmpeg was missing, entered the apt fallback, but the step was cancelled at exactly 3 minutes by the timeout-minutes guard. ## Fix Increased step timeout from 3 to 7 minutes. This accommodates two 180s shell timeouts (6 min) plus overhead, while still preventing indefinite hangs (the job-level 15-min timeout remains as the outer guard). ## Changed files - \.github/workflows/tutorial-preview-demo.yml\ — timeout-minutes: 3 → 7 on Setup FFmpeg step ## Validation - Same local Jest baseline: 40 suites, 381 tests, 380 passed, 1 skipped, 0 failed - Workflow remains manual-only via workflow_dispatch