### PR TITLE
fix(ci): increase apt timeouts to 300s for Tutorial Preview Demo

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
 
       - name: Setup FFmpeg
-        timeout-minutes: 7
+        timeout-minutes: 10
         run: |
           echo "--- FFmpeg availability check ---"
           if command -v ffmpeg &>/dev/null && command -v ffprobe &>/dev/null; then
@@ -36,9 +36,11 @@ jobs:
             echo "  ffmpeg path: $(which ffmpeg)"
             echo "  ffprobe path: $(which ffprobe)"
           else
-            echo "FFmpeg not found; installing via apt (timeout 180s per command)..."
-            timeout 180 sudo apt-get update -qq || { echo "ERROR: apt-get update timed out or failed" >&2; exit 1; }
-            timeout 180 sudo apt-get install -y -qq ffmpeg || { echo "ERROR: apt-get install ffmpeg timed out or failed" >&2; exit 1; }
+            echo "FFmpeg not found; installing via apt..."
+            echo "  apt-get update (timeout 300s)..."
+            timeout 300 sudo apt-get update -qq || { echo "ERROR: apt-get update timed out or failed" >&2; exit 1; }
+            echo "  apt-get install ffmpeg (timeout 300s)..."
+            timeout 300 sudo apt-get install -y -qq ffmpeg || { echo "ERROR: apt-get install ffmpeg timed out or failed" >&2; exit 1; }
             echo "  ffmpeg path: $(which ffmpeg)"
             echo "  ffprobe path: $(which ffprobe)"
           fi


### PR DESCRIPTION
Increase per-command shell timeout from 180s to 300s and step timeout from 7 to 10 minutes. Run 27775823217 confirmed 180s was too tight for current runner fleet.