### PR TITLE
fix(ci): use static FFmpeg build for Tutorial Preview Demo (apt mirrors unreliable)

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -28,23 +28,25 @@ jobs:
         run: npm ci
 
       - name: Setup FFmpeg
-        timeout-minutes: 10
+        timeout-minutes: 5
         run: |
           echo "--- FFmpeg availability check ---"
           if command -v ffmpeg &>/dev/null && command -v ffprobe &>/dev/null; then
             echo "FFmpeg is preinstalled on this runner."
-            echo "  ffmpeg path: $(which ffmpeg)"
-            echo "  ffprobe path: $(which ffprobe)"
           else
-            echo "FFmpeg not found; installing via apt..."
-            echo "  apt-get update (timeout 300s)..."
-            timeout 300 sudo apt-get update -qq || { echo "ERROR: apt-get update timed out or failed" >&2; exit 1; }
-            echo "  apt-get install ffmpeg (timeout 300s)..."
-            timeout 300 sudo apt-get install -y -qq ffmpeg || { echo "ERROR: apt-get install ffmpeg timed out or failed" >&2; exit 1; }
-            echo "  ffmpeg path: $(which ffmpeg)"
-            echo "  ffprobe path: $(which ffprobe)"
+            echo "FFmpeg not found; downloading static build from BtbN/FFmpeg-Builds..."
+            curl -sL "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz" \
+              -o /tmp/ffmpeg.tar.xz
+            mkdir -p /tmp/ffmpeg-extract
+            tar -xf /tmp/ffmpeg.tar.xz --strip-components=1 -C /tmp/ffmpeg-extract
+            sudo cp /tmp/ffmpeg-extract/bin/ffmpeg /usr/local/bin/ffmpeg
+            sudo cp /tmp/ffmpeg-extract/bin/ffprobe /usr/local/bin/ffprobe
+            sudo chmod +x /usr/local/bin/ffmpeg /usr/local/bin/ffprobe
+            rm -rf /tmp/ffmpeg.tar.xz /tmp/ffmpeg-extract
           fi
           echo "--- FFmpeg diagnostics ---"
+          echo "  ffmpeg path: $(which ffmpeg)"
+          echo "  ffprobe path: $(which ffprobe)"
           ffmpeg -version | head -3
           ffprobe -version | head -1
 


### PR DESCRIPTION
Switch from apt-get to BtbN/FFmpeg-Builds static binary download. Apt mirrors are consistently timing out on current GitHub runner fleet.