### PR TITLE
fix(ci): pin FFmpeg to n7.1.4 static build with SHA-256 verification and cache

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -8,6 +8,15 @@ on:
         required: false
         default: 'tests/fixtures/tutorial-vertical-slice/gem-collectors.json'
 
+# Pinned FFmpeg static build for deterministic rendering.
+# To upgrade: update FFMPEG_VERSION, FFMPEG_ARCHIVE, FFMPEG_URL, and FFMPEG_SHA256
+# from https://github.com/BtbN/FFmpeg-Builds/releases
+env:
+  FFMPEG_VERSION: 'n7.1.4-39-ga5faeca88f'
+  FFMPEG_ARCHIVE: 'ffmpeg-n7.1.4-39-ga5faeca88f-linux64-gpl-7.1.tar.xz'
+  FFMPEG_URL: 'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-15-15-03/ffmpeg-n7.1.4-39-ga5faeca88f-linux64-gpl-7.1.tar.xz'
+  FFMPEG_SHA256: 'dff1b3ba8401bc3520435d879be73eb21d7f884e0a149bd7139392be955a4942'
+
 jobs:
   generate-preview:
     name: Generate Tutorial Preview MP4
@@ -27,23 +36,49 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache FFmpeg static binaries
+        id: ffmpeg-cache
+        uses: actions/cache@v4
+        with:
+          path: /opt/ffmpeg
+          key: ffmpeg-${{ env.FFMPEG_VERSION }}-linux64-gpl
+
       - name: Setup FFmpeg
         timeout-minutes: 5
         run: |
-          echo "--- FFmpeg availability check ---"
+          echo "--- FFmpeg setup (pinned: $FFMPEG_VERSION) ---"
+
+          # Priority 1: preinstalled on runner
           if command -v ffmpeg &>/dev/null && command -v ffprobe &>/dev/null; then
-            echo "FFmpeg is preinstalled on this runner."
+            echo "source=preinstalled"
+            echo "  ffmpeg path: $(which ffmpeg)"
+            echo "  ffprobe path: $(which ffprobe)"
+          # Priority 2: cached binaries from previous run
+          elif [ -x /opt/ffmpeg/ffmpeg ] && [ -x /opt/ffmpeg/ffprobe ]; then
+            echo "source=cache"
+            sudo ln -sf /opt/ffmpeg/ffmpeg /usr/local/bin/ffmpeg
+            sudo ln -sf /opt/ffmpeg/ffprobe /usr/local/bin/ffprobe
+          # Priority 3: fresh download of pinned static build
           else
-            echo "FFmpeg not found; downloading static build from BtbN/FFmpeg-Builds..."
-            curl -sL "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz" \
-              -o /tmp/ffmpeg.tar.xz
+            echo "source=pinned-download"
+            echo "  Downloading $FFMPEG_ARCHIVE..."
+            curl -fsSL "$FFMPEG_URL" -o /tmp/ffmpeg.tar.xz
+            echo "  Verifying SHA-256..."
+            echo "$FFMPEG_SHA256  /tmp/ffmpeg.tar.xz" | sha256sum -c -
+            echo "  Extracting..."
             mkdir -p /tmp/ffmpeg-extract
             tar -xf /tmp/ffmpeg.tar.xz --strip-components=1 -C /tmp/ffmpeg-extract
-            sudo cp /tmp/ffmpeg-extract/bin/ffmpeg /usr/local/bin/ffmpeg
-            sudo cp /tmp/ffmpeg-extract/bin/ffprobe /usr/local/bin/ffprobe
-            sudo chmod +x /usr/local/bin/ffmpeg /usr/local/bin/ffprobe
+            # Install to /opt/ffmpeg for caching
+            sudo mkdir -p /opt/ffmpeg
+            sudo cp /tmp/ffmpeg-extract/bin/ffmpeg /opt/ffmpeg/ffmpeg
+            sudo cp /tmp/ffmpeg-extract/bin/ffprobe /opt/ffmpeg/ffprobe
+            sudo chmod +x /opt/ffmpeg/ffmpeg /opt/ffmpeg/ffprobe
+            # Symlink into PATH
+            sudo ln -sf /opt/ffmpeg/ffmpeg /usr/local/bin/ffmpeg
+            sudo ln -sf /opt/ffmpeg/ffprobe /usr/local/bin/ffprobe
             rm -rf /tmp/ffmpeg.tar.xz /tmp/ffmpeg-extract
           fi
+
           echo "--- FFmpeg diagnostics ---"
           echo "  ffmpeg path: $(which ffmpeg)"
           echo "  ffprobe path: $(which ffprobe)"


### PR DESCRIPTION
## Problem The Tutorial Preview Demo workflow downloads a moving latest FFmpeg build from BtbN/FFmpeg-Builds on every run. This weakens reproducibility for rendering and future golden validation. ## Fix - **Pinned version**: FFmpeg n7.1.4 from BtbN autobuild-2026-06-15-15-03 (immutable release tag) - **SHA-256 verification**: Download integrity checked before extraction - **actions/cache**: Extracted binaries cached at /opt/ffmpeg with key derived from version - **3-tier source detection**: preinstalled > cache > pinned-download, each logged clearly - **Upgrade path**: env vars at workflow top document how to bump version ## FFmpeg source details | Field | Value | |-------|-------| | Version | n7.1.4-39-ga5faeca88f | | Archive | ffmpeg-n7.1.4-39-ga5faeca88f-linux64-gpl-7.1.tar.xz | | Release tag | autobuild-2026-06-15-15-03 | | SHA-256 | dff1b3ba8401bc3520435d879be73eb21d7f884e0a149bd7139392be955a4942 | ## Changed files - .github/workflows/tutorial-preview-demo.yml ## Validation - Local Jest: 40 suites, 381 tests, 380 passed, 1 skipped, 0 failed - Workflow remains manual-only (workflow_dispatch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated FFmpeg setup in the tutorial preview workflow to use an explicitly pinned version with SHA-256 checksum verification
* Introduced binary caching for FFmpeg to optimize subsequent builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->