### PR TITLE
test: add artifact contract validator for Tutorial Preview Demo

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -120,6 +120,9 @@ jobs:
           " >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Validate artifact contract
+        run: npm run validate:tutorial-preview-artifact -- --dir out/tutorial-preview
+
       - name: Upload tutorial preview artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "storyboard:check": "node scripts/check_storyboard.cjs",
     "checklist:validate": "node scripts/validate_mobius_checklist.cjs",
     "mobius:e2e": "node scripts/run_mobius_e2e.cjs --game hanamikoji --lang en --resolution 1920x1080 --mode preview",
-    "demo:tutorial-preview": "node scripts/generate-tutorial-preview.mjs"
+    "demo:tutorial-preview": "node scripts/generate-tutorial-preview.mjs",
+    "validate:tutorial-preview-artifact": "node scripts/validate-tutorial-preview-artifact.mjs"
   },
   "keywords": [
     "game",

--- a/scripts/validate-tutorial-preview-artifact.mjs
+++ b/scripts/validate-tutorial-preview-artifact.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+/**
+ * validate-tutorial-preview-artifact.mjs — Artifact contract validator.
+ *
+ * Validates the tutorial preview output directory before upload to ensure
+ * all required files exist, are non-empty, and satisfy media/content contracts.
+ *
+ * Usage:
+ *   node scripts/validate-tutorial-preview-artifact.mjs
+ *   node scripts/validate-tutorial-preview-artifact.mjs --dir out/tutorial-preview
+ *
+ * Exit codes:
+ *   0 = all checks pass
+ *   1 = one or more contract violations found
+ */
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const dir = getArg('dir') || resolve('out/tutorial-preview');
+
+// ---------------------------------------------------------------------------
+// Validation framework
+// ---------------------------------------------------------------------------
+const errors = [];
+
+function fail(msg) {
+  errors.push(msg);
+}
+
+function requireFile(name) {
+  const filePath = join(dir, name);
+  if (!existsSync(filePath)) {
+    fail(`Missing required file: ${name}`);
+    return null;
+  }
+  const stat = statSync(filePath);
+  if (stat.size === 0) {
+    fail(`File is empty (0 bytes): ${name}`);
+    return null;
+  }
+  return filePath;
+}
+
+function loadJson(name) {
+  const filePath = requireFile(name);
+  if (!filePath) return null;
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    fail(`Invalid JSON in ${name}: ${err.message}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Required files check
+// ---------------------------------------------------------------------------
+console.log(`[validate] Artifact directory: ${dir}`);
+console.log('[validate] Checking required files...');
+
+const REQUIRED_FILES = [
+  'preview.mp4',
+  'script.json',
+  'storyboard.json',
+  'captions.srt',
+  'render-config.json',
+  'manifest.json',
+  'ffprobe.json',
+];
+
+for (const file of REQUIRED_FILES) {
+  requireFile(file);
+}
+
+// ---------------------------------------------------------------------------
+// ffprobe.json media contract
+// ---------------------------------------------------------------------------
+console.log('[validate] Checking ffprobe.json media contract...');
+
+const ffprobe = loadJson('ffprobe.json');
+if (ffprobe) {
+  const streams = ffprobe.streams || [];
+  const videoStream = streams.find((s) => s.codec_type === 'video');
+  const audioStream = streams.find((s) => s.codec_type === 'audio');
+
+  if (!videoStream) {
+    fail('ffprobe.json: no video stream found');
+  } else {
+    if (videoStream.codec_name !== 'h264') {
+      fail(`ffprobe.json: video codec is "${videoStream.codec_name}", expected "h264"`);
+    }
+    if (videoStream.width !== 1920) {
+      fail(`ffprobe.json: video width is ${videoStream.width}, expected 1920`);
+    }
+    if (videoStream.height !== 1080) {
+      fail(`ffprobe.json: video height is ${videoStream.height}, expected 1080`);
+    }
+    // Frame rate: r_frame_rate is a fraction like "30/1"
+    const fpsStr = videoStream.r_frame_rate || videoStream.avg_frame_rate || '';
+    const fpsParts = fpsStr.split('/');
+    const fpsValue = fpsParts.length === 2 ? Number(fpsParts[0]) / Number(fpsParts[1]) : Number(fpsStr);
+    if (isNaN(fpsValue) || fpsValue < 28 || fpsValue > 32) {
+      fail(`ffprobe.json: frame rate is ${fpsStr} (~${fpsValue}fps), expected ~30fps`);
+    }
+  }
+
+  if (!audioStream) {
+    fail('ffprobe.json: no audio stream found');
+  } else {
+    if (audioStream.codec_name !== 'aac') {
+      fail(`ffprobe.json: audio codec is "${audioStream.codec_name}", expected "aac"`);
+    }
+  }
+
+  // Duration from format
+  const duration = parseFloat(ffprobe.format?.duration || '0');
+  if (duration < 80 || duration > 90) {
+    fail(`ffprobe.json: duration is ${duration}s, expected between 80-90s`);
+  }
+
+  // Stream count
+  if (streams.length < 2) {
+    fail(`ffprobe.json: expected at least 2 streams (video+audio), found ${streams.length}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// script.json contract
+// ---------------------------------------------------------------------------
+console.log('[validate] Checking script.json contract...');
+
+const script = loadJson('script.json');
+if (script) {
+  const segments = script.segments;
+  if (!Array.isArray(segments)) {
+    fail('script.json: missing "segments" array');
+  } else {
+    if (segments.length < 10) {
+      fail(`script.json: segment count is ${segments.length}, expected at least 10`);
+    }
+    // Check that segments have required fields
+    const missingFields = segments.filter((s, i) => !s.id || !s.narration || !s.durationSec);
+    if (missingFields.length > 0) {
+      fail(`script.json: ${missingFields.length} segment(s) missing id, narration, or durationSec`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// storyboard.json contract
+// ---------------------------------------------------------------------------
+console.log('[validate] Checking storyboard.json contract...');
+
+const storyboard = loadJson('storyboard.json');
+if (storyboard) {
+  const scenes = storyboard.scenes;
+  if (!Array.isArray(scenes)) {
+    fail('storyboard.json: missing "scenes" array');
+  } else {
+    if (scenes.length < 10) {
+      fail(`storyboard.json: scene count is ${scenes.length}, expected at least 10`);
+    }
+    // Total duration check
+    const totalDuration = scenes.reduce((sum, s) => sum + (s.durationSec || 0), 0);
+    if (totalDuration <= 0) {
+      fail('storyboard.json: total scene duration is 0 or negative');
+    }
+    // Rough match to video duration (within 10s tolerance)
+    const ffprobeDuration = parseFloat(ffprobe?.format?.duration || '0');
+    if (ffprobeDuration > 0 && Math.abs(totalDuration - ffprobeDuration) > 10) {
+      fail(`storyboard.json: total scene duration (${totalDuration}s) differs from video duration (${ffprobeDuration}s) by more than 10s`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// captions.srt contract
+// ---------------------------------------------------------------------------
+console.log('[validate] Checking captions.srt contract...');
+
+const captionsPath = join(dir, 'captions.srt');
+if (existsSync(captionsPath) && statSync(captionsPath).size > 0) {
+  const srtContent = readFileSync(captionsPath, 'utf8');
+
+  // Count SRT cues: each cue starts with a number on its own line followed by a timestamp line
+  const cuePattern = /^\d+\s*\n\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/gm;
+  const cues = srtContent.match(cuePattern) || [];
+
+  if (cues.length < 20) {
+    fail(`captions.srt: found ${cues.length} cues, expected at least 20`);
+  }
+
+  // Verify sequential numbering starts at 1
+  const firstCueNum = parseInt(srtContent.trim().split('\n')[0], 10);
+  if (firstCueNum !== 1) {
+    fail(`captions.srt: first cue number is ${firstCueNum}, expected 1`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// render-config.json contract
+// ---------------------------------------------------------------------------
+console.log('[validate] Checking render-config.json contract...');
+
+const renderConfig = loadJson('render-config.json');
+if (renderConfig) {
+  if (!renderConfig.projectId) {
+    fail('render-config.json: missing "projectId"');
+  }
+  if (!renderConfig.video?.resolution?.width || !renderConfig.video?.resolution?.height) {
+    fail('render-config.json: missing video.resolution');
+  }
+  if (!renderConfig.video?.fps) {
+    fail('render-config.json: missing video.fps');
+  }
+  if (!Array.isArray(renderConfig.scenes) || renderConfig.scenes.length === 0) {
+    fail('render-config.json: missing or empty "scenes" array');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// manifest.json contract
+// ---------------------------------------------------------------------------
+console.log('[validate] Checking manifest.json contract...');
+
+const manifest = loadJson('manifest.json');
+if (manifest) {
+  if (!manifest.generatedAt) {
+    fail('manifest.json: missing "generatedAt"');
+  }
+  if (!manifest.game?.id || !manifest.game?.name) {
+    fail('manifest.json: missing "game.id" or "game.name"');
+  }
+  if (!manifest.script || !manifest.storyboard || !manifest.captions || !manifest.render) {
+    fail('manifest.json: missing pipeline summary fields (script, storyboard, captions, render)');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+console.log('');
+if (errors.length === 0) {
+  console.log(`[validate] ALL CHECKS PASSED (${REQUIRED_FILES.length} files, media contract, content contracts)`);
+  process.exit(0);
+} else {
+  console.error(`[validate] FAILED: ${errors.length} contract violation(s):`);
+  errors.forEach((e) => console.error(`  - ${e}`));
+  process.exit(1);
+}

--- a/tests/scripts/validateTutorialPreviewArtifact.test.js
+++ b/tests/scripts/validateTutorialPreviewArtifact.test.js
@@ -1,0 +1,276 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const VALIDATOR_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial-preview-artifact.mjs');
+
+function createTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tutorial-preview-validate-'));
+}
+
+function runValidator(dir, opts = {}) {
+  const result = { stdout: '', stderr: '', exitCode: 0 };
+  try {
+    const output = execFileSync('node', [VALIDATOR_SCRIPT, '--dir', dir], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 15000,
+      ...opts,
+    });
+    result.stdout = output;
+  } catch (err) {
+    result.stdout = err.stdout || '';
+    result.stderr = err.stderr || '';
+    result.exitCode = err.status || 1;
+  }
+  return result;
+}
+
+/**
+ * Creates a minimal valid artifact directory for testing.
+ */
+function createValidArtifact(dir) {
+  const ffprobeData = {
+    streams: [
+      {
+        codec_type: 'video',
+        codec_name: 'h264',
+        width: 1920,
+        height: 1080,
+        r_frame_rate: '30/1',
+      },
+      {
+        codec_type: 'audio',
+        codec_name: 'aac',
+      },
+    ],
+    format: {
+      duration: '85.000000',
+      size: '581180',
+    },
+  };
+
+  const segments = Array.from({ length: 17 }, (_, i) => ({
+    id: `seg-${i + 1}`,
+    type: i === 0 ? 'hook' : i === 16 ? 'end_card' : 'explanation',
+    narration: `This is narration for segment ${i + 1}.`,
+    durationSec: 5,
+  }));
+
+  const scriptData = {
+    segments,
+    warnings: [],
+    metadata: { totalDurationSec: 85, eliteS1Valid: true },
+  };
+
+  const storyboardData = {
+    scenes: segments.map((s) => ({
+      id: s.id,
+      durationSec: s.durationSec,
+      narration: s.narration,
+    })),
+  };
+
+  const renderConfigData = {
+    projectId: 'gem-collectors',
+    video: { resolution: { width: 1920, height: 1080 }, fps: 30 },
+    scenes: segments.map((s) => ({
+      id: s.id,
+      durationSec: s.durationSec,
+      background: { color: '#1a1a2e' },
+      overlays: [{ type: 'body', text: s.narration, position: 'center' }],
+    })),
+  };
+
+  const manifestData = {
+    generatedAt: '2026-06-18T17:50:58Z',
+    fixture: 'gem-collectors.json',
+    game: { id: 'gem-collectors', name: 'Gem Collectors' },
+    script: { segments: 17, totalDurationSec: 85 },
+    storyboard: { scenes: 17 },
+    captions: { cues: 34, totalDurationMs: 85000 },
+    render: { scenes: 17, mode: 'render' },
+  };
+
+  // Generate SRT with 34 cues
+  let srt = '';
+  for (let i = 1; i <= 34; i++) {
+    const startSec = (i - 1) * 2.5;
+    const endSec = startSec + 2.3;
+    const startTs = formatSrtTime(startSec);
+    const endTs = formatSrtTime(endSec);
+    srt += `${i}\n${startTs} --> ${endTs}\nCaption text for cue ${i}.\n\n`;
+  }
+
+  fs.writeFileSync(path.join(dir, 'preview.mp4'), Buffer.alloc(1024, 0xFF)); // Non-empty binary
+  fs.writeFileSync(path.join(dir, 'script.json'), JSON.stringify(scriptData, null, 2));
+  fs.writeFileSync(path.join(dir, 'storyboard.json'), JSON.stringify(storyboardData, null, 2));
+  fs.writeFileSync(path.join(dir, 'captions.srt'), srt);
+  fs.writeFileSync(path.join(dir, 'render-config.json'), JSON.stringify(renderConfigData, null, 2));
+  fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify(manifestData, null, 2));
+  fs.writeFileSync(path.join(dir, 'ffprobe.json'), JSON.stringify(ffprobeData, null, 2));
+}
+
+function formatSrtTime(totalSec) {
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = Math.floor(totalSec % 60);
+  const ms = Math.round((totalSec % 1) * 1000);
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')},${String(ms).padStart(3, '0')}`;
+}
+
+function cleanDir(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch { /* ignore */ }
+}
+
+describe('validate-tutorial-preview-artifact.mjs', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanDir(tmpDir);
+  });
+
+  describe('passes with valid artifact', () => {
+    test('exits 0 with all checks passed message', () => {
+      createValidArtifact(tmpDir);
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('ALL CHECKS PASSED');
+    });
+  });
+
+  describe('fails on missing files', () => {
+    test('exits 1 when preview.mp4 is missing', () => {
+      createValidArtifact(tmpDir);
+      fs.unlinkSync(path.join(tmpDir, 'preview.mp4'));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('preview.mp4');
+    });
+
+    test('exits 1 when script.json is missing', () => {
+      createValidArtifact(tmpDir);
+      fs.unlinkSync(path.join(tmpDir, 'script.json'));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('script.json');
+    });
+
+    test('exits 1 when ffprobe.json is missing', () => {
+      createValidArtifact(tmpDir);
+      fs.unlinkSync(path.join(tmpDir, 'ffprobe.json'));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('ffprobe.json');
+    });
+  });
+
+  describe('fails on zero-byte files', () => {
+    test('exits 1 when preview.mp4 is empty', () => {
+      createValidArtifact(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, 'preview.mp4'), '');
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('empty');
+      expect(result.stderr).toContain('preview.mp4');
+    });
+  });
+
+  describe('fails on invalid ffprobe.json', () => {
+    test('exits 1 when ffprobe.json has invalid JSON', () => {
+      createValidArtifact(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, 'ffprobe.json'), 'not json');
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid JSON');
+    });
+
+    test('exits 1 when no video stream in ffprobe.json', () => {
+      createValidArtifact(tmpDir);
+      const data = { streams: [{ codec_type: 'audio', codec_name: 'aac' }], format: { duration: '85.0' } };
+      fs.writeFileSync(path.join(tmpDir, 'ffprobe.json'), JSON.stringify(data));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no video stream');
+    });
+
+    test('exits 1 when no audio stream in ffprobe.json', () => {
+      createValidArtifact(tmpDir);
+      const data = {
+        streams: [{ codec_type: 'video', codec_name: 'h264', width: 1920, height: 1080, r_frame_rate: '30/1' }],
+        format: { duration: '85.0' },
+      };
+      fs.writeFileSync(path.join(tmpDir, 'ffprobe.json'), JSON.stringify(data));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no audio stream');
+    });
+
+    test('exits 1 when video resolution is wrong', () => {
+      createValidArtifact(tmpDir);
+      const data = {
+        streams: [
+          { codec_type: 'video', codec_name: 'h264', width: 1280, height: 720, r_frame_rate: '30/1' },
+          { codec_type: 'audio', codec_name: 'aac' },
+        ],
+        format: { duration: '85.0' },
+      };
+      fs.writeFileSync(path.join(tmpDir, 'ffprobe.json'), JSON.stringify(data));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('width');
+    });
+
+    test('exits 1 when duration is out of range', () => {
+      createValidArtifact(tmpDir);
+      const data = {
+        streams: [
+          { codec_type: 'video', codec_name: 'h264', width: 1920, height: 1080, r_frame_rate: '30/1' },
+          { codec_type: 'audio', codec_name: 'aac' },
+        ],
+        format: { duration: '30.0' },
+      };
+      fs.writeFileSync(path.join(tmpDir, 'ffprobe.json'), JSON.stringify(data));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('duration');
+    });
+  });
+
+  describe('fails on malformed captions.srt', () => {
+    test('exits 1 when captions.srt has fewer than 20 cues', () => {
+      createValidArtifact(tmpDir);
+      // Write only 5 cues
+      let srt = '';
+      for (let i = 1; i <= 5; i++) {
+        srt += `${i}\n00:00:0${i},000 --> 00:00:0${i},500\nShort.\n\n`;
+      }
+      fs.writeFileSync(path.join(tmpDir, 'captions.srt'), srt);
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('cues');
+    });
+  });
+
+  describe('fails on invalid script.json', () => {
+    test('exits 1 when segments count is less than 10', () => {
+      createValidArtifact(tmpDir);
+      const data = {
+        segments: [{ id: 's1', narration: 'Hello', durationSec: 5 }],
+        warnings: [],
+        metadata: {},
+      };
+      fs.writeFileSync(path.join(tmpDir, 'script.json'), JSON.stringify(data));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('segment count');
+    });
+  });
+});


### PR DESCRIPTION
## Summary Adds a deterministic artifact contract validator that runs in the Tutorial Preview Demo workflow before artifact upload, ensuring the generated tutorial preview satisfies all structural and media contracts. ## New files - **scripts/validate-tutorial-preview-artifact.mjs** — CLI validator checking all 7 required files, media properties, and content contracts - **tests/scripts/validateTutorialPreviewArtifact.test.js** — 12 unit tests covering pass/fail scenarios ## Changes - **package.json** — added \alidate:tutorial-preview-artifact\ script - **.github/workflows/tutorial-preview-demo.yml** — added \Validate artifact contract\ step after metadata capture, before upload ## What the validator checks | File | Checks | |------|--------| | preview.mp4 | exists, non-zero | | ffprobe.json | H.264 video, AAC audio, 1920x1080, ~30fps, 80-90s duration, 2+ streams | | script.json | valid JSON, 10+ segments, segments have id/narration/durationSec | | storyboard.json | valid JSON, 10+ scenes, positive total duration, matches video duration | | captions.srt | 20+ SRT cues, sequential numbering starting at 1 | | render-config.json | valid JSON, has projectId, resolution, fps, non-empty scenes | | manifest.json | valid JSON, has generatedAt, game.id, game.name, pipeline summaries | ## Validation - Local Jest: **41 suites, 393 tests, 392 passed, 1 skipped, 0 failed** - Workflow remains manual-only (workflow_dispatch) - No generated artifacts committed