### PR TITLE
test: add visual QA contract validator for contact sheet artifacts

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Generate visual QA contact sheet
         run: npm run generate:tutorial-preview-contact-sheet -- --video out/tutorial-preview/preview.mp4 --out-dir out/tutorial-preview/visual-qa --frames 8
 
+      - name: Validate visual QA contract
+        run: npm run validate:tutorial-preview-visual-qa -- --dir out/tutorial-preview/visual-qa
+
       - name: Upload tutorial preview artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "mobius:e2e": "node scripts/run_mobius_e2e.cjs --game hanamikoji --lang en --resolution 1920x1080 --mode preview",
     "demo:tutorial-preview": "node scripts/generate-tutorial-preview.mjs",
     "validate:tutorial-preview-artifact": "node scripts/validate-tutorial-preview-artifact.mjs",
-    "generate:tutorial-preview-contact-sheet": "node scripts/generate-tutorial-preview-contact-sheet.mjs"
+    "generate:tutorial-preview-contact-sheet": "node scripts/generate-tutorial-preview-contact-sheet.mjs",
+    "validate:tutorial-preview-visual-qa": "node scripts/validate-tutorial-preview-visual-qa.mjs"
   },
   "keywords": [
     "game",

--- a/scripts/validate-tutorial-preview-visual-qa.mjs
+++ b/scripts/validate-tutorial-preview-visual-qa.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+/**
+ * validate-tutorial-preview-visual-qa.mjs — Visual QA contract validator.
+ *
+ * Validates the visual QA output directory (contact sheet, frames, manifest)
+ * to ensure structural integrity before artifact upload.
+ *
+ * Usage:
+ *   node scripts/validate-tutorial-preview-visual-qa.mjs
+ *   node scripts/validate-tutorial-preview-visual-qa.mjs --dir out/tutorial-preview/visual-qa
+ *   node scripts/validate-tutorial-preview-visual-qa.mjs --dir out/tutorial-preview/visual-qa --expected-frames 8
+ *
+ * Exit codes:
+ *   0 = all checks pass
+ *   1 = one or more contract violations found
+ */
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const dir = getArg('dir') || resolve('out/tutorial-preview/visual-qa');
+const expectedFrames = parseInt(getArg('expected-frames') || '8', 10);
+const expectedCols = parseInt(getArg('expected-columns') || '4', 10);
+const expectedRows = parseInt(getArg('expected-rows') || '2', 10);
+
+// ---------------------------------------------------------------------------
+// Validation framework
+// ---------------------------------------------------------------------------
+const errors = [];
+
+function fail(msg) {
+  errors.push(msg);
+}
+
+function requireFile(filePath, label) {
+  if (!existsSync(filePath)) {
+    fail(`Missing required file: ${label}`);
+    return false;
+  }
+  const stat = statSync(filePath);
+  if (stat.size === 0) {
+    fail(`File is empty (0 bytes): ${label}`);
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Required files check
+// ---------------------------------------------------------------------------
+console.log(`[visual-qa-validate] Directory: ${dir}`);
+console.log(`[visual-qa-validate] Expected: ${expectedFrames} frames, ${expectedCols}x${expectedRows} grid`);
+console.log('[visual-qa-validate] Checking required files...');
+
+// Contact sheet
+requireFile(join(dir, 'contact-sheet.jpg'), 'contact-sheet.jpg');
+
+// Manifest
+const manifestPath = join(dir, 'visual-qa-manifest.json');
+const manifestExists = requireFile(manifestPath, 'visual-qa-manifest.json');
+
+// Frame files
+for (let i = 1; i <= expectedFrames; i++) {
+  const frameName = `frame-${String(i).padStart(2, '0')}.jpg`;
+  requireFile(join(dir, 'frames', frameName), `frames/${frameName}`);
+}
+
+// ---------------------------------------------------------------------------
+// Manifest contract validation
+// ---------------------------------------------------------------------------
+console.log('[visual-qa-validate] Checking visual-qa-manifest.json contract...');
+
+let manifest = null;
+if (manifestExists) {
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (err) {
+    fail(`Invalid JSON in visual-qa-manifest.json: ${err.message}`);
+  }
+}
+
+if (manifest) {
+  // Frame count
+  if (manifest.frameCount !== expectedFrames) {
+    fail(`Manifest frameCount is ${manifest.frameCount}, expected ${expectedFrames}`);
+  }
+
+  // Timestamps array
+  const timestamps = manifest.timestamps;
+  if (!Array.isArray(timestamps)) {
+    fail('Manifest missing "timestamps" array');
+  } else {
+    if (timestamps.length !== expectedFrames) {
+      fail(`Manifest timestamps has ${timestamps.length} entries, expected ${expectedFrames}`);
+    }
+
+    // All numeric
+    const nonNumeric = timestamps.filter((t) => typeof t !== 'number' || isNaN(t));
+    if (nonNumeric.length > 0) {
+      fail(`Manifest timestamps contains ${nonNumeric.length} non-numeric value(s)`);
+    }
+
+    // Strictly increasing
+    for (let i = 1; i < timestamps.length; i++) {
+      if (timestamps[i] <= timestamps[i - 1]) {
+        fail(`Manifest timestamps not strictly increasing: index ${i} (${timestamps[i]}) <= index ${i - 1} (${timestamps[i - 1]})`);
+        break;
+      }
+    }
+
+    // All > 0
+    if (timestamps.length > 0 && timestamps[0] <= 0) {
+      fail(`Manifest first timestamp is ${timestamps[0]}, expected > 0`);
+    }
+
+    // All < video duration (if available)
+    const videoDuration = manifest.videoDuration;
+    if (typeof videoDuration === 'number' && videoDuration > 0) {
+      const lastTs = timestamps[timestamps.length - 1];
+      if (lastTs >= videoDuration) {
+        fail(`Manifest last timestamp (${lastTs}) >= videoDuration (${videoDuration})`);
+      }
+    }
+  }
+
+  // Video duration range
+  const videoDuration = manifest.videoDuration;
+  if (typeof videoDuration !== 'number' || videoDuration < 80 || videoDuration > 90) {
+    fail(`Manifest videoDuration is ${videoDuration}, expected between 80-90 seconds`);
+  }
+
+  // Grid metadata
+  const grid = manifest.grid;
+  if (!grid) {
+    fail('Manifest missing "grid" object');
+  } else {
+    if (grid.cols !== expectedCols) {
+      fail(`Manifest grid.cols is ${grid.cols}, expected ${expectedCols}`);
+    }
+    if (grid.rows !== expectedRows) {
+      fail(`Manifest grid.rows is ${grid.rows}, expected ${expectedRows}`);
+    }
+  }
+
+  // Contact sheet reference
+  if (!manifest.contactSheet) {
+    fail('Manifest missing "contactSheet" path');
+  }
+
+  // FFmpeg version metadata
+  if (!manifest.ffmpegVersion) {
+    fail('Manifest missing "ffmpegVersion"');
+  }
+
+  // Frames array
+  const frames = manifest.frames;
+  if (!Array.isArray(frames)) {
+    fail('Manifest missing "frames" array');
+  } else {
+    if (frames.length !== expectedFrames) {
+      fail(`Manifest frames array has ${frames.length} entries, expected ${expectedFrames}`);
+    }
+    // Verify each frame has name and timestamp
+    const incomplete = frames.filter((f) => !f.name || typeof f.timestamp !== 'number');
+    if (incomplete.length > 0) {
+      fail(`Manifest frames: ${incomplete.length} entry(ies) missing "name" or "timestamp"`);
+    }
+    // Verify listed frames exist on disk
+    for (const frame of frames) {
+      if (frame.name) {
+        const framePath = join(dir, 'frames', frame.name);
+        if (!existsSync(framePath)) {
+          fail(`Frame listed in manifest not found on disk: frames/${frame.name}`);
+        }
+      }
+    }
+  }
+
+  // Verify contact sheet listed in manifest exists
+  if (manifest.contactSheet) {
+    const csPath = join(dir, manifest.contactSheet);
+    if (!existsSync(csPath)) {
+      fail(`Contact sheet listed in manifest not found: ${manifest.contactSheet}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+console.log('');
+if (errors.length === 0) {
+  console.log(`[visual-qa-validate] ALL CHECKS PASSED (${expectedFrames} frames, contact sheet, manifest contract)`);
+  process.exit(0);
+} else {
+  console.error(`[visual-qa-validate] FAILED: ${errors.length} contract violation(s):`);
+  errors.forEach((e) => console.error(`  - ${e}`));
+  process.exit(1);
+}

--- a/tests/scripts/validateTutorialPreviewVisualQa.test.js
+++ b/tests/scripts/validateTutorialPreviewVisualQa.test.js
@@ -1,0 +1,182 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const VALIDATOR_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial-preview-visual-qa.mjs');
+
+function createTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'visual-qa-validate-'));
+}
+
+function runValidator(dir, extraArgs = []) {
+  const result = { stdout: '', stderr: '', exitCode: 0 };
+  try {
+    const output = execFileSync('node', [VALIDATOR_SCRIPT, '--dir', dir, ...extraArgs], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 15000,
+    });
+    result.stdout = output;
+  } catch (err) {
+    result.stdout = err.stdout || '';
+    result.stderr = err.stderr || '';
+    result.exitCode = err.status || 1;
+  }
+  return result;
+}
+
+function createValidVisualQa(dir) {
+  const framesDir = path.join(dir, 'frames');
+  fs.mkdirSync(framesDir, { recursive: true });
+
+  // Create 8 frame files
+  for (let i = 1; i <= 8; i++) {
+    fs.writeFileSync(path.join(framesDir, `frame-${String(i).padStart(2, '0')}.jpg`), Buffer.alloc(1024, 0xFF));
+  }
+
+  // Contact sheet
+  fs.writeFileSync(path.join(dir, 'contact-sheet.jpg'), Buffer.alloc(2048, 0xFF));
+
+  // Manifest
+  const manifest = {
+    generatedAt: '2026-06-18T20:35:32.525Z',
+    sourceVideo: 'out/tutorial-preview/preview.mp4',
+    videoDuration: 85.022982,
+    frameCount: 8,
+    timestamps: [4.25, 15.18, 26.11, 37.05, 47.98, 58.91, 69.84, 80.77],
+    frames: Array.from({ length: 8 }, (_, i) => ({
+      name: `frame-${String(i + 1).padStart(2, '0')}.jpg`,
+      timestamp: [4.25, 15.18, 26.11, 37.05, 47.98, 58.91, 69.84, 80.77][i],
+    })),
+    contactSheet: 'contact-sheet.jpg',
+    grid: { cols: 4, rows: 2 },
+    ffmpegVersion: 'n7.1.4-39-ga5faeca88f-20260615 Copyright (c) 2000-2026 the FFmpeg developers',
+  };
+  fs.writeFileSync(path.join(dir, 'visual-qa-manifest.json'), JSON.stringify(manifest, null, 2));
+}
+
+function cleanDir(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+describe('validate-tutorial-preview-visual-qa.mjs', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanDir(tmpDir);
+  });
+
+  describe('passes with valid visual QA output', () => {
+    test('exits 0 with all checks passed message', () => {
+      createValidVisualQa(tmpDir);
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('ALL CHECKS PASSED');
+    });
+  });
+
+  describe('fails on missing contact-sheet.jpg', () => {
+    test('exits 1 when contact-sheet.jpg is missing', () => {
+      createValidVisualQa(tmpDir);
+      fs.unlinkSync(path.join(tmpDir, 'contact-sheet.jpg'));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('contact-sheet.jpg');
+    });
+  });
+
+  describe('fails on zero-byte contact sheet', () => {
+    test('exits 1 when contact-sheet.jpg is empty', () => {
+      createValidVisualQa(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, 'contact-sheet.jpg'), '');
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('empty');
+      expect(result.stderr).toContain('contact-sheet.jpg');
+    });
+  });
+
+  describe('fails on missing frame', () => {
+    test('exits 1 when frame-04.jpg is missing', () => {
+      createValidVisualQa(tmpDir);
+      fs.unlinkSync(path.join(tmpDir, 'frames', 'frame-04.jpg'));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('frame-04.jpg');
+    });
+  });
+
+  describe('fails on zero-byte frame', () => {
+    test('exits 1 when a frame file is empty', () => {
+      createValidVisualQa(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, 'frames', 'frame-02.jpg'), '');
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('empty');
+      expect(result.stderr).toContain('frame-02.jpg');
+    });
+  });
+
+  describe('fails on malformed manifest', () => {
+    test('exits 1 when manifest is not valid JSON', () => {
+      createValidVisualQa(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), 'not json');
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid JSON');
+    });
+  });
+
+  describe('fails on wrong frame count', () => {
+    test('exits 1 when manifest frameCount does not match expected', () => {
+      createValidVisualQa(tmpDir);
+      const manifest = JSON.parse(fs.readFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), 'utf8'));
+      manifest.frameCount = 4;
+      fs.writeFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), JSON.stringify(manifest));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('frameCount');
+    });
+  });
+
+  describe('fails on non-increasing timestamps', () => {
+    test('exits 1 when timestamps are not strictly increasing', () => {
+      createValidVisualQa(tmpDir);
+      const manifest = JSON.parse(fs.readFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), 'utf8'));
+      manifest.timestamps = [4.25, 15.18, 10.0, 37.05, 47.98, 58.91, 69.84, 80.77];
+      fs.writeFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), JSON.stringify(manifest));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('increasing');
+    });
+  });
+
+  describe('fails on invalid grid layout', () => {
+    test('exits 1 when grid cols/rows do not match expected', () => {
+      createValidVisualQa(tmpDir);
+      const manifest = JSON.parse(fs.readFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), 'utf8'));
+      manifest.grid = { cols: 2, rows: 4 };
+      fs.writeFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), JSON.stringify(manifest));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('grid.cols');
+    });
+  });
+
+  describe('fails on missing FFmpeg metadata', () => {
+    test('exits 1 when ffmpegVersion is absent', () => {
+      createValidVisualQa(tmpDir);
+      const manifest = JSON.parse(fs.readFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), 'utf8'));
+      delete manifest.ffmpegVersion;
+      fs.writeFileSync(path.join(tmpDir, 'visual-qa-manifest.json'), JSON.stringify(manifest));
+      const result = runValidator(tmpDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('ffmpegVersion');
+    });
+  });
+});


### PR DESCRIPTION
## Summary Adds a structural contract validator for the visual QA contact sheet outputs, closing the QA loop around the new human-review artifacts. ## New files - **scripts/validate-tutorial-preview-visual-qa.mjs** — CLI validator for visual QA directory - **tests/scripts/validateTutorialPreviewVisualQa.test.js** — 10 unit tests covering pass/fail scenarios ## Changes - **package.json** — added \alidate:tutorial-preview-visual-qa\ script - **.github/workflows/tutorial-preview-demo.yml** — added \Validate visual QA contract\ step after contact-sheet generation, before upload ## Workflow step order (after merge) 1. Capture media metadata 2. Validate artifact contract (core 7 files) 3. Generate visual QA contact sheet 4. **Validate visual QA contract** (new) 5. Upload tutorial preview artifacts ## What the validator checks | Check | Details | |-------|---------| | contact-sheet.jpg | exists, non-zero | | visual-qa-manifest.json | valid JSON, correct structure | | frames/frame-01..08.jpg | all exist, all non-zero | | Manifest frameCount | exactly 8 | | Manifest timestamps | 8 entries, numeric, strictly increasing, >0, <duration | | Manifest grid | 4 cols x 2 rows | | Manifest contactSheet | path reference present | | Manifest ffmpegVersion | metadata present | | Manifest videoDuration | 80-90s range | | Cross-reference | frames in manifest exist on disk | ## Validation - Local Jest: **43 suites, 411 tests, 410 passed, 1 skipped, 0 failed** - Workflow remains manual-only (workflow_dispatch) - No generated artifacts committed