### PR TITLE
test: add golden metadata baseline for Tutorial Preview Demo

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Validate visual QA contract
         run: npm run validate:tutorial-preview-visual-qa -- --dir out/tutorial-preview/visual-qa
 
+      - name: Validate golden metadata baseline
+        run: npm run validate:tutorial-preview-golden-baseline -- --dir out/tutorial-preview --baseline tests/golden/tutorial-preview/gem-collectors-baseline.json
+
       - name: Upload tutorial preview artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "demo:tutorial-preview": "node scripts/generate-tutorial-preview.mjs",
     "validate:tutorial-preview-artifact": "node scripts/validate-tutorial-preview-artifact.mjs",
     "generate:tutorial-preview-contact-sheet": "node scripts/generate-tutorial-preview-contact-sheet.mjs",
-    "validate:tutorial-preview-visual-qa": "node scripts/validate-tutorial-preview-visual-qa.mjs"
+    "validate:tutorial-preview-visual-qa": "node scripts/validate-tutorial-preview-visual-qa.mjs",
+    "validate:tutorial-preview-golden-baseline": "node scripts/validate-tutorial-preview-golden-baseline.mjs"
   },
   "keywords": [
     "game",

--- a/scripts/validate-tutorial-preview-golden-baseline.mjs
+++ b/scripts/validate-tutorial-preview-golden-baseline.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+/**
+ * validate-tutorial-preview-golden-baseline.mjs — Golden metadata baseline validator.
+ *
+ * Compares generated tutorial preview metadata against a committed baseline JSON,
+ * failing if any stable field drifts outside explicit tolerances.
+ *
+ * Usage:
+ *   node scripts/validate-tutorial-preview-golden-baseline.mjs
+ *   node scripts/validate-tutorial-preview-golden-baseline.mjs --dir out/tutorial-preview --baseline tests/golden/tutorial-preview/gem-collectors-baseline.json
+ *
+ * Exit codes:
+ *   0 = generated metadata matches baseline within tolerances
+ *   1 = one or more baseline drifts detected
+ */
+
+import { existsSync, readFileSync, statSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const dir = getArg('dir') || resolve('out/tutorial-preview');
+const baselinePath = getArg('baseline') || resolve('tests/golden/tutorial-preview/gem-collectors-baseline.json');
+
+// ---------------------------------------------------------------------------
+// Load baseline
+// ---------------------------------------------------------------------------
+if (!existsSync(baselinePath)) {
+  console.error(`Baseline file not found: ${baselinePath}`);
+  process.exit(1);
+}
+
+let baseline;
+try {
+  baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+} catch (err) {
+  console.error(`Invalid baseline JSON: ${err.message}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Validation framework
+// ---------------------------------------------------------------------------
+const errors = [];
+
+function fail(key, msg) {
+  errors.push(`[${key}] ${msg}`);
+}
+
+function loadJson(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function getFileSize(filePath) {
+  try {
+    return statSync(filePath).size;
+  } catch {
+    return -1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validate
+// ---------------------------------------------------------------------------
+console.log('[golden-baseline] Tutorial Preview Golden Metadata Validation');
+console.log(`  dir: ${dir}`);
+console.log(`  baseline: ${baselinePath}`);
+
+// --- Core files existence ---
+console.log('[golden-baseline] Checking core file list...');
+if (baseline.coreFiles) {
+  for (const file of baseline.coreFiles) {
+    if (!existsSync(join(dir, file))) {
+      fail('coreFiles', `Missing: ${file}`);
+    }
+  }
+}
+
+// --- Visual QA files existence ---
+console.log('[golden-baseline] Checking visual QA file list...');
+if (baseline.visualQaFiles) {
+  for (const file of baseline.visualQaFiles) {
+    if (!existsSync(join(dir, file))) {
+      fail('visualQaFiles', `Missing: ${file}`);
+    }
+  }
+}
+
+// --- Script segment count ---
+console.log('[golden-baseline] Checking script.json...');
+const script = loadJson(join(dir, 'script.json'));
+if (script && baseline.script) {
+  const actual = script.segments?.length || 0;
+  const expected = baseline.script.segmentCount;
+  if (actual !== expected) {
+    fail('script.segmentCount', `actual=${actual}, expected=${expected}`);
+  }
+}
+
+// --- Storyboard scene count ---
+console.log('[golden-baseline] Checking storyboard.json...');
+const storyboard = loadJson(join(dir, 'storyboard.json'));
+if (storyboard && baseline.storyboard) {
+  const actual = storyboard.scenes?.length || 0;
+  const expected = baseline.storyboard.sceneCount;
+  if (actual !== expected) {
+    fail('storyboard.sceneCount', `actual=${actual}, expected=${expected}`);
+  }
+}
+
+// --- Caption cue count ---
+console.log('[golden-baseline] Checking captions.srt...');
+const captionsPath = join(dir, 'captions.srt');
+if (existsSync(captionsPath) && baseline.captions) {
+  const srt = readFileSync(captionsPath, 'utf8');
+  const cuePattern = /^\d+\s*\n\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}/gm;
+  const actual = (srt.match(cuePattern) || []).length;
+  const expected = baseline.captions.cueCount;
+  if (actual !== expected) {
+    fail('captions.cueCount', `actual=${actual}, expected=${expected}`);
+  }
+}
+
+// --- Render config scene count ---
+console.log('[golden-baseline] Checking render-config.json...');
+const renderConfig = loadJson(join(dir, 'render-config.json'));
+if (renderConfig && baseline.renderConfig) {
+  const actual = renderConfig.scenes?.length || 0;
+  const expected = baseline.renderConfig.sceneCount;
+  if (actual !== expected) {
+    fail('renderConfig.sceneCount', `actual=${actual}, expected=${expected}`);
+  }
+}
+
+// --- Video metadata from ffprobe.json ---
+console.log('[golden-baseline] Checking ffprobe.json video metadata...');
+const ffprobe = loadJson(join(dir, 'ffprobe.json'));
+if (ffprobe && baseline.video) {
+  const bv = baseline.video;
+  const streams = ffprobe.streams || [];
+  const videoStream = streams.find((s) => s.codec_type === 'video');
+  const audioStream = streams.find((s) => s.codec_type === 'audio');
+
+  if (videoStream) {
+    if (videoStream.codec_name !== bv.codec) {
+      fail('video.codec', `actual="${videoStream.codec_name}", expected="${bv.codec}"`);
+    }
+    if (videoStream.width !== bv.width) {
+      fail('video.width', `actual=${videoStream.width}, expected=${bv.width}`);
+    }
+    if (videoStream.height !== bv.height) {
+      fail('video.height', `actual=${videoStream.height}, expected=${bv.height}`);
+    }
+    const fpsStr = videoStream.r_frame_rate || videoStream.avg_frame_rate || '';
+    const fpsParts = fpsStr.split('/');
+    const fpsValue = fpsParts.length === 2 ? Number(fpsParts[0]) / Number(fpsParts[1]) : Number(fpsStr);
+    if (Math.abs(fpsValue - bv.fps) > 1) {
+      fail('video.fps', `actual=${fpsValue}, expected=${bv.fps}`);
+    }
+  } else {
+    fail('video', 'No video stream found in ffprobe.json');
+  }
+
+  if (audioStream) {
+    if (audioStream.codec_name !== bv.audioCodec) {
+      fail('video.audioCodec', `actual="${audioStream.codec_name}", expected="${bv.audioCodec}"`);
+    }
+  } else {
+    fail('video', 'No audio stream found in ffprobe.json');
+  }
+
+  if (bv.streamCount && streams.length !== bv.streamCount) {
+    fail('video.streamCount', `actual=${streams.length}, expected=${bv.streamCount}`);
+  }
+
+  const duration = parseFloat(ffprobe.format?.duration || '0');
+  if (bv.durationRange) {
+    if (duration < bv.durationRange.min || duration > bv.durationRange.max) {
+      fail('video.duration', `actual=${duration}s, expected ${bv.durationRange.min}-${bv.durationRange.max}s`);
+    }
+  }
+}
+
+// --- Visual QA manifest metadata ---
+console.log('[golden-baseline] Checking visual-qa-manifest.json...');
+const vqaManifest = loadJson(join(dir, 'visual-qa/visual-qa-manifest.json'));
+if (vqaManifest && baseline.visualQa) {
+  const bvq = baseline.visualQa;
+
+  if (vqaManifest.frameCount !== bvq.frameCount) {
+    fail('visualQa.frameCount', `actual=${vqaManifest.frameCount}, expected=${bvq.frameCount}`);
+  }
+
+  if (vqaManifest.grid) {
+    if (vqaManifest.grid.cols !== bvq.grid.cols) {
+      fail('visualQa.grid.cols', `actual=${vqaManifest.grid.cols}, expected=${bvq.grid.cols}`);
+    }
+    if (vqaManifest.grid.rows !== bvq.grid.rows) {
+      fail('visualQa.grid.rows', `actual=${vqaManifest.grid.rows}, expected=${bvq.grid.rows}`);
+    }
+  }
+
+  // Timestamp comparison with tolerance
+  if (Array.isArray(vqaManifest.timestamps) && Array.isArray(bvq.timestamps)) {
+    const tol = bvq.timestampTolerance || 1.0;
+    for (let i = 0; i < bvq.timestamps.length; i++) {
+      const actual = vqaManifest.timestamps[i];
+      const expected = bvq.timestamps[i];
+      if (actual === undefined) {
+        fail('visualQa.timestamps', `missing timestamp at index ${i}`);
+      } else if (Math.abs(actual - expected) > tol) {
+        fail('visualQa.timestamps', `index ${i}: actual=${actual}, expected=${expected} (tol=${tol})`);
+      }
+    }
+  }
+
+  // FFmpeg version prefix
+  if (bvq.ffmpegVersionPrefix && vqaManifest.ffmpegVersion) {
+    if (!vqaManifest.ffmpegVersion.startsWith(bvq.ffmpegVersionPrefix)) {
+      fail('visualQa.ffmpegVersion', `actual="${vqaManifest.ffmpegVersion}", expected prefix="${bvq.ffmpegVersionPrefix}"`);
+    }
+  }
+}
+
+// --- File size ranges ---
+console.log('[golden-baseline] Checking file size ranges...');
+if (baseline.fileSizeRanges) {
+  for (const [pattern, range] of Object.entries(baseline.fileSizeRanges)) {
+    if (pattern.includes('*')) {
+      // Glob pattern for frames: check all matching files
+      const baseDir = join(dir, pattern.replace('/*', ''));
+      if (existsSync(baseDir)) {
+        const files = readdirSync(baseDir).filter((f) => f.endsWith('.jpg'));
+        for (const file of files) {
+          const size = getFileSize(join(baseDir, file));
+          if (size < range.min || size > range.max) {
+            fail('fileSizeRanges', `${pattern.replace('*', file)}: size=${size}, expected ${range.min}-${range.max}`);
+          }
+        }
+      }
+    } else {
+      const size = getFileSize(join(dir, pattern));
+      if (size >= 0 && (size < range.min || size > range.max)) {
+        fail('fileSizeRanges', `${pattern}: size=${size}, expected ${range.min}-${range.max}`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+console.log('');
+if (errors.length === 0) {
+  console.log('[golden-baseline] ALL CHECKS PASSED — generated metadata matches baseline within tolerances');
+  process.exit(0);
+} else {
+  console.error(`[golden-baseline] FAILED: ${errors.length} baseline drift(s) detected:`);
+  errors.forEach((e) => console.error(`  - ${e}`));
+  process.exit(1);
+}

--- a/tests/golden/tutorial-preview/gem-collectors-baseline.json
+++ b/tests/golden/tutorial-preview/gem-collectors-baseline.json
@@ -1,0 +1,79 @@
+{
+  "_schema": "Tutorial Preview Golden Metadata Baseline",
+  "_description": "Stable metadata expectations for the gem-collectors tutorial preview vertical slice. Update this file deliberately after approved render/storyboard/fixture changes.",
+  "_updated": "2026-06-18",
+
+  "fixture": {
+    "gameId": "gem-collectors",
+    "gameName": "Gem Collectors"
+  },
+
+  "coreFiles": [
+    "preview.mp4",
+    "script.json",
+    "storyboard.json",
+    "captions.srt",
+    "render-config.json",
+    "manifest.json",
+    "ffprobe.json"
+  ],
+
+  "visualQaFiles": [
+    "visual-qa/contact-sheet.jpg",
+    "visual-qa/visual-qa-manifest.json",
+    "visual-qa/frames/frame-01.jpg",
+    "visual-qa/frames/frame-02.jpg",
+    "visual-qa/frames/frame-03.jpg",
+    "visual-qa/frames/frame-04.jpg",
+    "visual-qa/frames/frame-05.jpg",
+    "visual-qa/frames/frame-06.jpg",
+    "visual-qa/frames/frame-07.jpg",
+    "visual-qa/frames/frame-08.jpg"
+  ],
+
+  "script": {
+    "segmentCount": 11
+  },
+
+  "storyboard": {
+    "sceneCount": 13
+  },
+
+  "captions": {
+    "cueCount": 23
+  },
+
+  "renderConfig": {
+    "sceneCount": 11
+  },
+
+  "video": {
+    "codec": "h264",
+    "audioCodec": "aac",
+    "width": 1920,
+    "height": 1080,
+    "fps": 30,
+    "durationRange": { "min": 80, "max": 90 },
+    "streamCount": 2
+  },
+
+  "visualQa": {
+    "frameCount": 8,
+    "grid": { "cols": 4, "rows": 2 },
+    "timestamps": [4.25, 15.18, 26.11, 37.05, 47.98, 58.91, 69.84, 80.77],
+    "timestampTolerance": 1.0,
+    "ffmpegVersionPrefix": "n7.1.4"
+  },
+
+  "fileSizeRanges": {
+    "preview.mp4": { "min": 400000, "max": 800000 },
+    "script.json": { "min": 2000, "max": 8000 },
+    "storyboard.json": { "min": 5000, "max": 20000 },
+    "captions.srt": { "min": 1000, "max": 5000 },
+    "render-config.json": { "min": 2000, "max": 10000 },
+    "manifest.json": { "min": 400, "max": 2000 },
+    "ffprobe.json": { "min": 2000, "max": 10000 },
+    "visual-qa/contact-sheet.jpg": { "min": 20000, "max": 200000 },
+    "visual-qa/frames/*": { "min": 20000, "max": 150000 }
+  }
+}

--- a/tests/scripts/validateTutorialPreviewGoldenBaseline.test.js
+++ b/tests/scripts/validateTutorialPreviewGoldenBaseline.test.js
@@ -1,0 +1,250 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const VALIDATOR_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial-preview-golden-baseline.mjs');
+
+function createTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'golden-baseline-validate-'));
+}
+
+function runValidator(dir, baselinePath, extraArgs = []) {
+  const result = { stdout: '', stderr: '', exitCode: 0 };
+  try {
+    const output = execFileSync('node', [VALIDATOR_SCRIPT, '--dir', dir, '--baseline', baselinePath, ...extraArgs], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 15000,
+    });
+    result.stdout = output;
+  } catch (err) {
+    result.stdout = err.stdout || '';
+    result.stderr = err.stderr || '';
+    result.exitCode = err.status || 1;
+  }
+  return result;
+}
+
+function createValidBaseline() {
+  return {
+    fixture: { gameId: 'gem-collectors', gameName: 'Gem Collectors' },
+    coreFiles: ['preview.mp4', 'script.json', 'storyboard.json', 'captions.srt', 'render-config.json', 'manifest.json', 'ffprobe.json'],
+    visualQaFiles: ['visual-qa/contact-sheet.jpg', 'visual-qa/visual-qa-manifest.json'],
+    script: { segmentCount: 11 },
+    storyboard: { sceneCount: 13 },
+    captions: { cueCount: 23 },
+    renderConfig: { sceneCount: 11 },
+    video: { codec: 'h264', audioCodec: 'aac', width: 1920, height: 1080, fps: 30, durationRange: { min: 80, max: 90 }, streamCount: 2 },
+    visualQa: { frameCount: 8, grid: { cols: 4, rows: 2 }, timestamps: [4.25, 15.18, 26.11, 37.05, 47.98, 58.91, 69.84, 80.77], timestampTolerance: 1.0, ffmpegVersionPrefix: 'n7.1.4' },
+    fileSizeRanges: { 'preview.mp4': { min: 400, max: 800000 }, 'script.json': { min: 100, max: 80000 } },
+  };
+}
+
+function createValidArtifactDir(dir) {
+  const vqaDir = path.join(dir, 'visual-qa', 'frames');
+  fs.mkdirSync(vqaDir, { recursive: true });
+
+  // Core files
+  fs.writeFileSync(path.join(dir, 'preview.mp4'), Buffer.alloc(1024, 0xFF));
+  fs.writeFileSync(path.join(dir, 'script.json'), JSON.stringify({
+    segments: Array.from({ length: 11 }, (_, i) => ({ id: `s${i}`, narration: 'text', durationSec: 5 })),
+  }));
+  fs.writeFileSync(path.join(dir, 'storyboard.json'), JSON.stringify({
+    scenes: Array.from({ length: 13 }, (_, i) => ({ id: `sc${i}`, durationSec: 6.5 })),
+  }));
+  // captions.srt with 23 cues
+  let srt = '';
+  for (let i = 1; i <= 23; i++) {
+    srt += `${i}\n00:00:${String(i).padStart(2, '0')},000 --> 00:00:${String(i).padStart(2, '0')},500\nCue ${i}\n\n`;
+  }
+  fs.writeFileSync(path.join(dir, 'captions.srt'), srt);
+  fs.writeFileSync(path.join(dir, 'render-config.json'), JSON.stringify({
+    projectId: 'gem-collectors',
+    video: { resolution: { width: 1920, height: 1080 }, fps: 30 },
+    scenes: Array.from({ length: 11 }, (_, i) => ({ id: `s${i}`, durationSec: 5, background: { color: '#000' } })),
+  }));
+  fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify({ generatedAt: '2026-01-01', game: { id: 'gem-collectors', name: 'Gem Collectors' } }));
+  fs.writeFileSync(path.join(dir, 'ffprobe.json'), JSON.stringify({
+    streams: [
+      { codec_type: 'video', codec_name: 'h264', width: 1920, height: 1080, r_frame_rate: '30/1' },
+      { codec_type: 'audio', codec_name: 'aac' },
+    ],
+    format: { duration: '85.0', size: '581180' },
+  }));
+
+  // Visual QA
+  fs.writeFileSync(path.join(dir, 'visual-qa', 'contact-sheet.jpg'), Buffer.alloc(512, 0xFF));
+  fs.writeFileSync(path.join(dir, 'visual-qa', 'visual-qa-manifest.json'), JSON.stringify({
+    frameCount: 8, grid: { cols: 4, rows: 2 },
+    timestamps: [4.25, 15.18, 26.11, 37.05, 47.98, 58.91, 69.84, 80.77],
+    ffmpegVersion: 'n7.1.4-39-ga5faeca88f-20260615 Copyright',
+  }));
+}
+
+function cleanDir(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+describe('validate-tutorial-preview-golden-baseline.mjs', () => {
+  let tmpDir;
+  let baselineFile;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+    baselineFile = path.join(tmpDir, 'baseline.json');
+  });
+
+  afterEach(() => {
+    cleanDir(tmpDir);
+  });
+
+  describe('passes with valid metadata', () => {
+    test('exits 0 when generated metadata matches baseline', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      fs.writeFileSync(baselineFile, JSON.stringify(createValidBaseline()));
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('ALL CHECKS PASSED');
+    });
+  });
+
+  describe('fails on segment count drift', () => {
+    test('exits 1 when script segment count differs', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      const bl = createValidBaseline();
+      bl.script.segmentCount = 15;
+      fs.writeFileSync(baselineFile, JSON.stringify(bl));
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('script.segmentCount');
+    });
+  });
+
+  describe('fails on storyboard scene count drift', () => {
+    test('exits 1 when storyboard scene count differs', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      const bl = createValidBaseline();
+      bl.storyboard.sceneCount = 20;
+      fs.writeFileSync(baselineFile, JSON.stringify(bl));
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('storyboard.sceneCount');
+    });
+  });
+
+  describe('fails on caption cue count drift', () => {
+    test('exits 1 when caption cue count differs', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      const bl = createValidBaseline();
+      bl.captions.cueCount = 50;
+      fs.writeFileSync(baselineFile, JSON.stringify(bl));
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('captions.cueCount');
+    });
+  });
+
+  describe('fails on video duration outside range', () => {
+    test('exits 1 when duration is outside baseline range', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      // Override ffprobe with short duration
+      fs.writeFileSync(path.join(artDir, 'ffprobe.json'), JSON.stringify({
+        streams: [
+          { codec_type: 'video', codec_name: 'h264', width: 1920, height: 1080, r_frame_rate: '30/1' },
+          { codec_type: 'audio', codec_name: 'aac' },
+        ],
+        format: { duration: '30.0' },
+      }));
+      fs.writeFileSync(baselineFile, JSON.stringify(createValidBaseline()));
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('video.duration');
+    });
+  });
+
+  describe('fails on wrong codec', () => {
+    test('exits 1 when video codec does not match baseline', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      fs.writeFileSync(path.join(artDir, 'ffprobe.json'), JSON.stringify({
+        streams: [
+          { codec_type: 'video', codec_name: 'vp9', width: 1920, height: 1080, r_frame_rate: '30/1' },
+          { codec_type: 'audio', codec_name: 'aac' },
+        ],
+        format: { duration: '85.0' },
+      }));
+      fs.writeFileSync(baselineFile, JSON.stringify(createValidBaseline()));
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('video.codec');
+    });
+  });
+
+  describe('fails on visual QA timestamp drift', () => {
+    test('exits 1 when timestamps drift beyond tolerance', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      // Override VQA manifest with drifted timestamps
+      fs.writeFileSync(path.join(artDir, 'visual-qa', 'visual-qa-manifest.json'), JSON.stringify({
+        frameCount: 8, grid: { cols: 4, rows: 2 },
+        timestamps: [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0],
+        ffmpegVersion: 'n7.1.4-test',
+      }));
+      fs.writeFileSync(baselineFile, JSON.stringify(createValidBaseline()));
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('visualQa.timestamps');
+    });
+  });
+
+  describe('fails on file size outside range', () => {
+    test('exits 1 when preview.mp4 is too small', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      // Make preview.mp4 tiny (10 bytes) — below min of 400
+      fs.writeFileSync(path.join(artDir, 'preview.mp4'), Buffer.alloc(10));
+      fs.writeFileSync(baselineFile, JSON.stringify(createValidBaseline()));
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('fileSizeRanges');
+      expect(result.stderr).toContain('preview.mp4');
+    });
+  });
+
+  describe('fails on missing baseline file', () => {
+    test('exits 1 when baseline path does not exist', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      const result = runValidator(artDir, path.join(tmpDir, 'nonexistent.json'));
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('not found');
+    });
+  });
+
+  describe('fails on malformed baseline', () => {
+    test('exits 1 when baseline is not valid JSON', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifactDir(artDir);
+      fs.writeFileSync(baselineFile, 'not json at all');
+      const result = runValidator(artDir, baselineFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid baseline JSON');
+    });
+  });
+});


### PR DESCRIPTION
## Summary Adds the first golden metadata baseline for the gem-collectors tutorial preview vertical slice. The workflow now fails before upload if generated metadata drifts outside explicit tolerances — creating a reproducibility gate without committing binary artifacts. ## New files - **tests/golden/tutorial-preview/gem-collectors-baseline.json** — committed baseline with expected counts, codecs, duration range, file size ranges, timestamps, and tolerances - **scripts/validate-tutorial-preview-golden-baseline.mjs** — CLI validator comparing generated artifacts against baseline - **tests/scripts/validateTutorialPreviewGoldenBaseline.test.js** — 10 unit tests ## Changes - **package.json** — added \alidate:tutorial-preview-golden-baseline\ script - **.github/workflows/tutorial-preview-demo.yml** — added \Validate golden metadata baseline\ step after visual QA validator, before upload ## Workflow step order (after merge) 1. Validate artifact contract (core 7 files) 2. Generate visual QA contact sheet 3. Validate visual QA contract 4. **Validate golden metadata baseline** (new) 5. Upload tutorial preview artifacts ## Baseline keys covered | Key | Expected | |-----|----------| | script.segmentCount | 11 | | storyboard.sceneCount | 13 | | captions.cueCount | 23 | | renderConfig.sceneCount | 11 | | video.codec | h264 | | video.audioCodec | aac | | video.resolution | 1920x1080 | | video.fps | 30 | | video.duration | 80-90s | | video.streamCount | 2 | | visualQa.frameCount | 8 | | visualQa.grid | 4x2 | | visualQa.timestamps | 8 values (tol 1.0s) | | visualQa.ffmpegVersion | prefix n7.1.4 | | fileSizeRanges | broad min/max for all outputs | ## How to update the baseline After an approved render/storyboard/fixture change: 1. Trigger Tutorial Preview Demo manually 2. Inspect the failing baseline drift messages 3. Update \	ests/golden/tutorial-preview/gem-collectors-baseline.json\ with the new expected values 4. Commit and PR the updated baseline ## Validation - Local Jest: **44 suites, 421 tests, 420 passed, 1 skipped, 0 failed** - No binary artifacts committed - Workflow remains manual-only (workflow_dispatch)