### PR TITLE
test: add golden frame fingerprint baseline for Tutorial Preview Demo

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -132,6 +132,9 @@ jobs:
       - name: Validate golden metadata baseline
         run: npm run validate:tutorial-preview-golden-baseline -- --dir out/tutorial-preview --baseline tests/golden/tutorial-preview/gem-collectors-baseline.json
 
+      - name: Validate golden frame fingerprints
+        run: npm run validate:tutorial-preview-frame-fingerprints -- --dir out/tutorial-preview --baseline tests/golden/tutorial-preview/gem-collectors-frame-fingerprints.json
+
       - name: Upload tutorial preview artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "validate:tutorial-preview-artifact": "node scripts/validate-tutorial-preview-artifact.mjs",
     "generate:tutorial-preview-contact-sheet": "node scripts/generate-tutorial-preview-contact-sheet.mjs",
     "validate:tutorial-preview-visual-qa": "node scripts/validate-tutorial-preview-visual-qa.mjs",
-    "validate:tutorial-preview-golden-baseline": "node scripts/validate-tutorial-preview-golden-baseline.mjs"
+    "validate:tutorial-preview-golden-baseline": "node scripts/validate-tutorial-preview-golden-baseline.mjs",
+    "validate:tutorial-preview-frame-fingerprints": "node scripts/validate-tutorial-preview-frame-fingerprints.mjs"
   },
   "keywords": [
     "game",

--- a/scripts/validate-tutorial-preview-frame-fingerprints.mjs
+++ b/scripts/validate-tutorial-preview-frame-fingerprints.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * validate-tutorial-preview-frame-fingerprints.mjs — Golden frame fingerprint validator.
+ *
+ * Compares SHA-256 hashes and byte sizes of generated visual QA frames/contact sheet
+ * against a committed fingerprint baseline. Detects unintended visual drift at the
+ * byte level without requiring subjective visual scoring.
+ *
+ * Usage:
+ *   node scripts/validate-tutorial-preview-frame-fingerprints.mjs
+ *   node scripts/validate-tutorial-preview-frame-fingerprints.mjs --dir out/tutorial-preview --baseline tests/golden/tutorial-preview/gem-collectors-frame-fingerprints.json
+ *
+ * Exit codes:
+ *   0 = all fingerprints match baseline
+ *   1 = one or more fingerprint drifts detected
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const dir = getArg('dir') || resolve('out/tutorial-preview');
+const baselinePath = getArg('baseline') || resolve('tests/golden/tutorial-preview/gem-collectors-frame-fingerprints.json');
+
+// ---------------------------------------------------------------------------
+// Load baseline
+// ---------------------------------------------------------------------------
+if (!existsSync(baselinePath)) {
+  console.error(`Baseline file not found: ${baselinePath}`);
+  process.exit(1);
+}
+
+let baseline;
+try {
+  baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+} catch (err) {
+  console.error(`Invalid baseline JSON: ${err.message}`);
+  process.exit(1);
+}
+
+if (!Array.isArray(baseline.images) || baseline.images.length === 0) {
+  console.error('Baseline has no "images" array or it is empty');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Load visual QA manifest for timestamp cross-reference
+// ---------------------------------------------------------------------------
+const manifestPath = join(dir, 'visual-qa/visual-qa-manifest.json');
+let manifest = null;
+if (existsSync(manifestPath)) {
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch { /* ignored — timestamp checks will be skipped */ }
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+const errors = [];
+const timestampTolerance = baseline.timestampTolerance || 0.5;
+
+function fail(msg) {
+  errors.push(msg);
+}
+
+function computeSha256(filePath) {
+  const buf = readFileSync(filePath);
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+console.log('[frame-fingerprints] Golden Visual Fingerprint Validation');
+console.log(`  dir: ${dir}`);
+console.log(`  baseline: ${baselinePath}`);
+console.log(`  images: ${baseline.images.length}`);
+console.log(`  timestamp tolerance: ${timestampTolerance}s`);
+console.log('');
+
+for (const entry of baseline.images) {
+  const filePath = join(dir, entry.path);
+  const label = entry.path;
+
+  // File existence
+  if (!existsSync(filePath)) {
+    fail(`[${label}] Missing file`);
+    continue;
+  }
+
+  // Non-zero check
+  const stat = statSync(filePath);
+  if (stat.size === 0) {
+    fail(`[${label}] File is empty (0 bytes)`);
+    continue;
+  }
+
+  // SHA-256 hash comparison
+  const actualHash = computeSha256(filePath);
+  if (actualHash !== entry.sha256) {
+    fail(`[${label}] SHA-256 drift: expected=${entry.sha256.slice(0, 16)}..., actual=${actualHash.slice(0, 16)}...`);
+  }
+
+  // Byte size comparison
+  if (stat.size !== entry.size) {
+    fail(`[${label}] Size drift: expected=${entry.size}, actual=${stat.size}`);
+  }
+
+  // Timestamp cross-reference for frames
+  if (entry.role === 'frame' && entry.timestamp !== undefined && manifest) {
+    const manifestTs = manifest.timestamps?.[entry.index - 1];
+    if (manifestTs !== undefined) {
+      if (Math.abs(manifestTs - entry.timestamp) > timestampTolerance) {
+        fail(`[${label}] Timestamp drift: baseline=${entry.timestamp}, manifest=${manifestTs} (tol=${timestampTolerance})`);
+      }
+    }
+  }
+
+  // Log success per image
+  if (!errors.some((e) => e.startsWith(`[${label}]`))) {
+    console.log(`  OK ${label} (${stat.size} bytes, hash matches)`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+console.log('');
+if (errors.length === 0) {
+  console.log(`[frame-fingerprints] ALL FINGERPRINTS MATCH (${baseline.images.length} images verified)`);
+  process.exit(0);
+} else {
+  console.error(`[frame-fingerprints] FAILED: ${errors.length} fingerprint drift(s) detected:`);
+  errors.forEach((e) => console.error(`  - ${e}`));
+  process.exit(1);
+}

--- a/tests/golden/tutorial-preview/gem-collectors-frame-fingerprints.json
+++ b/tests/golden/tutorial-preview/gem-collectors-frame-fingerprints.json
@@ -1,0 +1,83 @@
+{
+  "_description": "Golden visual fingerprint baseline for Tutorial Preview Demo frames. Update deliberately after approved rendering changes.",
+  "_baselineVersion": 1,
+  "_sourceRunId": 27790449616,
+  "_sourceHeadSha": "83be0ec3903a1da5d66f161693d11c23bf0e948d",
+  "_ffmpegVersionPrefix": "n7.1.4",
+  "_updated": "2026-06-18",
+
+  "timestampTolerance": 0.5,
+
+  "images": [
+    {
+      "path": "visual-qa/contact-sheet.jpg",
+      "role": "contactSheet",
+      "sha256": "10d4e4b63ad4b4b55639003915b61b5f3b2ef05175a2eef8dfd0adb95d0459ac",
+      "size": 43733
+    },
+    {
+      "path": "visual-qa/frames/frame-01.jpg",
+      "role": "frame",
+      "index": 1,
+      "timestamp": 4.25,
+      "sha256": "fbbc70284a7ffae82a04c387ba5807e4490b7db609dd98fdf646164c4cf0c460",
+      "size": 55224
+    },
+    {
+      "path": "visual-qa/frames/frame-02.jpg",
+      "role": "frame",
+      "index": 2,
+      "timestamp": 15.18,
+      "sha256": "1add100f2fbd0deca54d5f91dd12b89ff085914d67f9599b1ac292511a361490",
+      "size": 48073
+    },
+    {
+      "path": "visual-qa/frames/frame-03.jpg",
+      "role": "frame",
+      "index": 3,
+      "timestamp": 26.11,
+      "sha256": "803575ab11cdcdb5ec0f0d48d3aebbd54a3ede6f0abf638fa9e360d57f60ba81",
+      "size": 52587
+    },
+    {
+      "path": "visual-qa/frames/frame-04.jpg",
+      "role": "frame",
+      "index": 4,
+      "timestamp": 37.05,
+      "sha256": "0999fe1168be6493ab1e641864864b2f3365beaadab6433bbf7511479436c1a4",
+      "size": 50642
+    },
+    {
+      "path": "visual-qa/frames/frame-05.jpg",
+      "role": "frame",
+      "index": 5,
+      "timestamp": 47.98,
+      "sha256": "629f1dd5c2bcaf1a43ccdfe0f0caf011128b072ff7fa494c2f095870c062303a",
+      "size": 52802
+    },
+    {
+      "path": "visual-qa/frames/frame-06.jpg",
+      "role": "frame",
+      "index": 6,
+      "timestamp": 58.91,
+      "sha256": "a665ad10bec781a625bac32a69413e62c3077eccb9870168510d1e07076ec9f3",
+      "size": 52096
+    },
+    {
+      "path": "visual-qa/frames/frame-07.jpg",
+      "role": "frame",
+      "index": 7,
+      "timestamp": 69.84,
+      "sha256": "860dc1db6a8a6fee29464d633c0f9d654161b4318bf108c09cddc6ef85ec6f1e",
+      "size": 52171
+    },
+    {
+      "path": "visual-qa/frames/frame-08.jpg",
+      "role": "frame",
+      "index": 8,
+      "timestamp": 80.77,
+      "sha256": "9b6fbb1f84a753f577fa5ab0cb90c85c31e7ebebf11a86413d32b3ea7ff1193f",
+      "size": 42798
+    }
+  ]
+}

--- a/tests/scripts/validateTutorialPreviewFrameFingerprints.test.js
+++ b/tests/scripts/validateTutorialPreviewFrameFingerprints.test.js
@@ -1,0 +1,238 @@
+const { execFileSync } = require('child_process');
+const crypto = require('crypto');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const VALIDATOR_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial-preview-frame-fingerprints.mjs');
+
+function createTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'frame-fingerprints-validate-'));
+}
+
+function runValidator(dir, baselinePath) {
+  const result = { stdout: '', stderr: '', exitCode: 0 };
+  try {
+    const output = execFileSync('node', [VALIDATOR_SCRIPT, '--dir', dir, '--baseline', baselinePath], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 15000,
+    });
+    result.stdout = output;
+  } catch (err) {
+    result.stdout = err.stdout || '';
+    result.stderr = err.stderr || '';
+    result.exitCode = err.status || 1;
+  }
+  return result;
+}
+
+function sha256(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function createValidArtifact(dir) {
+  const framesDir = path.join(dir, 'visual-qa', 'frames');
+  fs.mkdirSync(framesDir, { recursive: true });
+
+  const images = [];
+  const timestamps = [];
+
+  // Contact sheet
+  const csData = Buffer.from('contact-sheet-content-for-test');
+  fs.writeFileSync(path.join(dir, 'visual-qa', 'contact-sheet.jpg'), csData);
+  images.push({ path: 'visual-qa/contact-sheet.jpg', role: 'contactSheet', sha256: sha256(csData), size: csData.length });
+
+  // 8 frames
+  for (let i = 1; i <= 8; i++) {
+    const frameData = Buffer.from(`frame-${i}-content-deterministic-test-data`);
+    const frameName = `frame-${String(i).padStart(2, '0')}.jpg`;
+    fs.writeFileSync(path.join(framesDir, frameName), frameData);
+    const ts = 4.0 + (i - 1) * 10.5;
+    timestamps.push(ts);
+    images.push({
+      path: `visual-qa/frames/${frameName}`,
+      role: 'frame',
+      index: i,
+      timestamp: ts,
+      sha256: sha256(frameData),
+      size: frameData.length,
+    });
+  }
+
+  // Visual QA manifest
+  fs.writeFileSync(path.join(dir, 'visual-qa', 'visual-qa-manifest.json'), JSON.stringify({
+    frameCount: 8,
+    timestamps,
+    grid: { cols: 4, rows: 2 },
+    ffmpegVersion: 'n7.1.4-test',
+  }));
+
+  return { images, timestamps };
+}
+
+function createBaseline(images) {
+  return { _baselineVersion: 1, timestampTolerance: 0.5, images };
+}
+
+function cleanDir(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+describe('validate-tutorial-preview-frame-fingerprints.mjs', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanDir(tmpDir);
+  });
+
+  describe('passes with valid fingerprints', () => {
+    test('exits 0 when all hashes match', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { images } = createValidArtifact(artDir);
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(images)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('ALL FINGERPRINTS MATCH');
+    });
+  });
+
+  describe('fails on missing baseline file', () => {
+    test('exits 1 when baseline path does not exist', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifact(artDir);
+      const result = runValidator(artDir, path.join(tmpDir, 'nonexistent.json'));
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('not found');
+    });
+  });
+
+  describe('fails on malformed baseline', () => {
+    test('exits 1 when baseline is not valid JSON', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifact(artDir);
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, 'not json');
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid baseline JSON');
+    });
+  });
+
+  describe('fails on missing contact sheet', () => {
+    test('exits 1 when contact-sheet.jpg is missing', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { images } = createValidArtifact(artDir);
+      fs.unlinkSync(path.join(artDir, 'visual-qa', 'contact-sheet.jpg'));
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(images)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Missing file');
+      expect(result.stderr).toContain('contact-sheet.jpg');
+    });
+  });
+
+  describe('fails on missing frame', () => {
+    test('exits 1 when a frame file is missing', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { images } = createValidArtifact(artDir);
+      fs.unlinkSync(path.join(artDir, 'visual-qa', 'frames', 'frame-05.jpg'));
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(images)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Missing file');
+      expect(result.stderr).toContain('frame-05.jpg');
+    });
+  });
+
+  describe('fails on zero-byte frame', () => {
+    test('exits 1 when a frame is empty', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { images } = createValidArtifact(artDir);
+      fs.writeFileSync(path.join(artDir, 'visual-qa', 'frames', 'frame-03.jpg'), '');
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(images)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('empty');
+    });
+  });
+
+  describe('fails on hash drift', () => {
+    test('exits 1 when a frame hash does not match baseline', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { images } = createValidArtifact(artDir);
+      // Overwrite frame-02 with different content
+      fs.writeFileSync(path.join(artDir, 'visual-qa', 'frames', 'frame-02.jpg'), 'different-content');
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(images)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('SHA-256 drift');
+      expect(result.stderr).toContain('frame-02.jpg');
+    });
+  });
+
+  describe('fails on byte-size drift', () => {
+    test('exits 1 when file size does not match baseline', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { images } = createValidArtifact(artDir);
+      // Modify baseline to expect different size for contact sheet
+      const modImages = [...images];
+      modImages[0] = { ...modImages[0], size: 99999 };
+      // But keep the hash correct (so only size check fails)
+      modImages[0].sha256 = sha256(fs.readFileSync(path.join(artDir, 'visual-qa', 'contact-sheet.jpg')));
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(modImages)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Size drift');
+    });
+  });
+
+  describe('fails on timestamp drift', () => {
+    test('exits 1 when manifest timestamp drifts beyond tolerance', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { images } = createValidArtifact(artDir);
+      // Override manifest with drifted timestamps
+      const manifestPath = path.join(artDir, 'visual-qa', 'visual-qa-manifest.json');
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      manifest.timestamps[0] = 50.0; // Huge drift from baseline 4.0
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(images)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Timestamp drift');
+    });
+  });
+
+  describe('fails on empty images array in baseline', () => {
+    test('exits 1 when baseline has no images', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifact(artDir);
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify({ images: [] }));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('empty');
+    });
+  });
+});


### PR DESCRIPTION
Adds byte-level SHA-256 fingerprint validation for all 9 visual QA images (contact sheet + 8 frames). Baseline derived from run 27790449616. Validates hashes, sizes, and timestamps before upload. Local Jest: 45 suites, 431 tests, 430 passed, 1 skipped, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for frame fingerprint validation scenarios.

* **Chores**
  * Integrated frame fingerprint validation into CI/CD pipeline to ensure visual consistency of tutorial preview frames through SHA-256 hash and size verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->