### PR TITLE
test: add golden MP4 bitstream fingerprint baseline for Tutorial Preview Demo

### DIFF
--- a/.github/workflows/tutorial-preview-demo.yml
+++ b/.github/workflows/tutorial-preview-demo.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Validate golden frame fingerprints
         run: npm run validate:tutorial-preview-frame-fingerprints -- --dir out/tutorial-preview --baseline tests/golden/tutorial-preview/gem-collectors-frame-fingerprints.json
 
+      - name: Validate golden MP4 fingerprint
+        run: npm run validate:tutorial-preview-mp4-fingerprint -- --dir out/tutorial-preview --baseline tests/golden/tutorial-preview/gem-collectors-mp4-fingerprint.json
+
       - name: Upload tutorial preview artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "generate:tutorial-preview-contact-sheet": "node scripts/generate-tutorial-preview-contact-sheet.mjs",
     "validate:tutorial-preview-visual-qa": "node scripts/validate-tutorial-preview-visual-qa.mjs",
     "validate:tutorial-preview-golden-baseline": "node scripts/validate-tutorial-preview-golden-baseline.mjs",
-    "validate:tutorial-preview-frame-fingerprints": "node scripts/validate-tutorial-preview-frame-fingerprints.mjs"
+    "validate:tutorial-preview-frame-fingerprints": "node scripts/validate-tutorial-preview-frame-fingerprints.mjs",
+    "validate:tutorial-preview-mp4-fingerprint": "node scripts/validate-tutorial-preview-mp4-fingerprint.mjs"
   },
   "keywords": [
     "game",

--- a/scripts/validate-tutorial-preview-mp4-fingerprint.mjs
+++ b/scripts/validate-tutorial-preview-mp4-fingerprint.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+/**
+ * validate-tutorial-preview-mp4-fingerprint.mjs — Golden MP4 bitstream fingerprint validator.
+ *
+ * Compares the SHA-256 hash and byte size of generated preview.mp4 against a
+ * committed fingerprint baseline. Optionally cross-checks media metadata from
+ * ffprobe.json against baseline expectations.
+ *
+ * Usage:
+ *   node scripts/validate-tutorial-preview-mp4-fingerprint.mjs
+ *   node scripts/validate-tutorial-preview-mp4-fingerprint.mjs --dir out/tutorial-preview --baseline tests/golden/tutorial-preview/gem-collectors-mp4-fingerprint.json
+ *
+ * Exit codes:
+ *   0 = MP4 fingerprint matches baseline
+ *   1 = fingerprint drift or validation failure
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const dir = getArg('dir') || resolve('out/tutorial-preview');
+const baselinePath = getArg('baseline') || resolve('tests/golden/tutorial-preview/gem-collectors-mp4-fingerprint.json');
+
+// ---------------------------------------------------------------------------
+// Load baseline
+// ---------------------------------------------------------------------------
+if (!existsSync(baselinePath)) {
+  console.error(`Baseline file not found: ${baselinePath}`);
+  process.exit(1);
+}
+
+let baseline;
+try {
+  baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+} catch (err) {
+  console.error(`Invalid baseline JSON: ${err.message}`);
+  process.exit(1);
+}
+
+if (!baseline.file || !baseline.sha256 || !baseline.size) {
+  console.error('Baseline missing required fields: file, sha256, size');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+const errors = [];
+
+function fail(msg) {
+  errors.push(msg);
+}
+
+const mp4Path = join(dir, baseline.file);
+
+console.log('[mp4-fingerprint] Golden MP4 Bitstream Fingerprint Validation');
+console.log(`  dir: ${dir}`);
+console.log(`  baseline: ${baselinePath}`);
+console.log(`  file: ${baseline.file}`);
+console.log(`  expected SHA-256: ${baseline.sha256}`);
+console.log(`  expected size: ${baseline.size} bytes`);
+console.log('');
+
+// File existence
+if (!existsSync(mp4Path)) {
+  fail(`Missing file: ${baseline.file}`);
+} else {
+  const stat = statSync(mp4Path);
+
+  // Non-zero check
+  if (stat.size === 0) {
+    fail(`File is empty (0 bytes): ${baseline.file}`);
+  } else {
+    // SHA-256 comparison
+    const buf = readFileSync(mp4Path);
+    const actualHash = createHash('sha256').update(buf).digest('hex');
+
+    if (actualHash !== baseline.sha256) {
+      fail(`SHA-256 drift: expected=${baseline.sha256}, actual=${actualHash}`);
+    } else {
+      console.log(`  SHA-256: MATCH (${actualHash.slice(0, 16)}...)`);
+    }
+
+    // Byte size comparison
+    if (stat.size !== baseline.size) {
+      fail(`Size drift: expected=${baseline.size}, actual=${stat.size}`);
+    } else {
+      console.log(`  Size: MATCH (${stat.size} bytes)`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Optional media metadata cross-check via ffprobe.json
+// ---------------------------------------------------------------------------
+if (baseline.expectedMedia) {
+  const ffprobePath = join(dir, 'ffprobe.json');
+  if (existsSync(ffprobePath)) {
+    console.log('');
+    console.log('[mp4-fingerprint] Cross-checking media metadata from ffprobe.json...');
+    try {
+      const ffprobe = JSON.parse(readFileSync(ffprobePath, 'utf8'));
+      const streams = ffprobe.streams || [];
+      const videoStream = streams.find((s) => s.codec_type === 'video');
+      const audioStream = streams.find((s) => s.codec_type === 'audio');
+      const em = baseline.expectedMedia;
+
+      if (videoStream) {
+        if (em.videoCodec && videoStream.codec_name !== em.videoCodec) {
+          fail(`Media: video codec "${videoStream.codec_name}" != expected "${em.videoCodec}"`);
+        }
+        if (em.width && videoStream.width !== em.width) {
+          fail(`Media: width ${videoStream.width} != expected ${em.width}`);
+        }
+        if (em.height && videoStream.height !== em.height) {
+          fail(`Media: height ${videoStream.height} != expected ${em.height}`);
+        }
+        if (em.fps) {
+          const fpsStr = videoStream.r_frame_rate || videoStream.avg_frame_rate || '';
+          const parts = fpsStr.split('/');
+          const fpsVal = parts.length === 2 ? Number(parts[0]) / Number(parts[1]) : Number(fpsStr);
+          if (Math.abs(fpsVal - em.fps) > 1) {
+            fail(`Media: fps ${fpsVal} != expected ${em.fps}`);
+          }
+        }
+      } else {
+        fail('Media: no video stream in ffprobe.json');
+      }
+
+      if (audioStream) {
+        if (em.audioCodec && audioStream.codec_name !== em.audioCodec) {
+          fail(`Media: audio codec "${audioStream.codec_name}" != expected "${em.audioCodec}"`);
+        }
+      } else {
+        fail('Media: no audio stream in ffprobe.json');
+      }
+
+      if (em.streamCount && streams.length !== em.streamCount) {
+        fail(`Media: stream count ${streams.length} != expected ${em.streamCount}`);
+      }
+
+      const duration = parseFloat(ffprobe.format?.duration || '0');
+      if (em.durationRange && (duration < em.durationRange.min || duration > em.durationRange.max)) {
+        fail(`Media: duration ${duration}s outside expected ${em.durationRange.min}-${em.durationRange.max}s`);
+      }
+
+      if (errors.length === 0) {
+        console.log('  Media metadata: ALL MATCH');
+      }
+    } catch (err) {
+      console.log(`  Warning: could not parse ffprobe.json for cross-check: ${err.message}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+console.log('');
+if (errors.length === 0) {
+  console.log('[mp4-fingerprint] MP4 FINGERPRINT MATCHES BASELINE');
+  process.exit(0);
+} else {
+  console.error(`[mp4-fingerprint] FAILED: ${errors.length} drift(s) detected:`);
+  errors.forEach((e) => console.error(`  - ${e}`));
+  process.exit(1);
+}

--- a/tests/golden/tutorial-preview/gem-collectors-mp4-fingerprint.json
+++ b/tests/golden/tutorial-preview/gem-collectors-mp4-fingerprint.json
@@ -1,0 +1,22 @@
+{
+  "_description": "Golden MP4 bitstream fingerprint for Tutorial Preview Demo. Update deliberately after approved rendering/FFmpeg/storyboard changes.",
+  "_baselineVersion": 1,
+  "_sourceRunId": 27828672285,
+  "_sourceHeadSha": "c4f6f42f825cc7312103d288a0a7c4fefc4563ad",
+  "_ffmpegVersionPrefix": "n7.1.4",
+  "_updated": "2026-06-19",
+
+  "file": "preview.mp4",
+  "sha256": "183126452f9baee89ca3f63543e1c788352ca8db05b28d8e388a6a0e241895bb",
+  "size": 581180,
+
+  "expectedMedia": {
+    "videoCodec": "h264",
+    "audioCodec": "aac",
+    "width": 1920,
+    "height": 1080,
+    "fps": 30,
+    "durationRange": { "min": 80, "max": 90 },
+    "streamCount": 2
+  }
+}

--- a/tests/scripts/validateTutorialPreviewMp4Fingerprint.test.js
+++ b/tests/scripts/validateTutorialPreviewMp4Fingerprint.test.js
@@ -1,0 +1,210 @@
+const { execFileSync } = require('child_process');
+const crypto = require('crypto');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const VALIDATOR_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial-preview-mp4-fingerprint.mjs');
+
+function createTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mp4-fingerprint-validate-'));
+}
+
+function runValidator(dir, baselinePath) {
+  const result = { stdout: '', stderr: '', exitCode: 0 };
+  try {
+    const output = execFileSync('node', [VALIDATOR_SCRIPT, '--dir', dir, '--baseline', baselinePath], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 15000,
+    });
+    result.stdout = output;
+  } catch (err) {
+    result.stdout = err.stdout || '';
+    result.stderr = err.stderr || '';
+    result.exitCode = err.status || 1;
+  }
+  return result;
+}
+
+function sha256(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function createValidArtifact(dir) {
+  const mp4Data = Buffer.from('fake-mp4-content-for-deterministic-testing-1234567890');
+  fs.writeFileSync(path.join(dir, 'preview.mp4'), mp4Data);
+
+  // ffprobe.json for metadata cross-check
+  fs.writeFileSync(path.join(dir, 'ffprobe.json'), JSON.stringify({
+    streams: [
+      { codec_type: 'video', codec_name: 'h264', width: 1920, height: 1080, r_frame_rate: '30/1' },
+      { codec_type: 'audio', codec_name: 'aac' },
+    ],
+    format: { duration: '85.0', size: String(mp4Data.length) },
+  }));
+
+  return { mp4Data, hash: sha256(mp4Data), size: mp4Data.length };
+}
+
+function createBaseline(hash, size) {
+  return {
+    _baselineVersion: 1,
+    file: 'preview.mp4',
+    sha256: hash,
+    size: size,
+    expectedMedia: {
+      videoCodec: 'h264',
+      audioCodec: 'aac',
+      width: 1920,
+      height: 1080,
+      fps: 30,
+      durationRange: { min: 80, max: 90 },
+      streamCount: 2,
+    },
+  };
+}
+
+function cleanDir(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+describe('validate-tutorial-preview-mp4-fingerprint.mjs', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanDir(tmpDir);
+  });
+
+  describe('passes with valid MP4 hash', () => {
+    test('exits 0 when hash and size match', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { hash, size } = createValidArtifact(artDir);
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(hash, size)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('MP4 FINGERPRINT MATCHES BASELINE');
+    });
+  });
+
+  describe('fails on missing baseline file', () => {
+    test('exits 1 when baseline does not exist', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifact(artDir);
+      const result = runValidator(artDir, path.join(tmpDir, 'nonexistent.json'));
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('not found');
+    });
+  });
+
+  describe('fails on malformed baseline', () => {
+    test('exits 1 when baseline is not valid JSON', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      createValidArtifact(artDir);
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, 'not json');
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid baseline JSON');
+    });
+  });
+
+  describe('fails on missing preview.mp4', () => {
+    test('exits 1 when preview.mp4 does not exist', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      // No preview.mp4 created
+      fs.writeFileSync(path.join(artDir, 'ffprobe.json'), '{}');
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline('abc123', 1000)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Missing file');
+    });
+  });
+
+  describe('fails on zero-byte preview.mp4', () => {
+    test('exits 1 when preview.mp4 is empty', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      fs.writeFileSync(path.join(artDir, 'preview.mp4'), '');
+      fs.writeFileSync(path.join(artDir, 'ffprobe.json'), '{}');
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline('abc123', 1000)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('empty');
+    });
+  });
+
+  describe('fails on hash drift', () => {
+    test('exits 1 when SHA-256 does not match baseline', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { size } = createValidArtifact(artDir);
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline('0000000000000000000000000000000000000000000000000000000000000000', size)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('SHA-256 drift');
+    });
+  });
+
+  describe('fails on byte-size drift', () => {
+    test('exits 1 when size does not match baseline', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { hash } = createValidArtifact(artDir);
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(hash, 99999)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Size drift');
+    });
+  });
+
+  describe('fails on codec metadata drift', () => {
+    test('exits 1 when ffprobe shows wrong codec', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const { hash, size } = createValidArtifact(artDir);
+      // Override ffprobe with wrong codec
+      fs.writeFileSync(path.join(artDir, 'ffprobe.json'), JSON.stringify({
+        streams: [
+          { codec_type: 'video', codec_name: 'vp9', width: 1920, height: 1080, r_frame_rate: '30/1' },
+          { codec_type: 'audio', codec_name: 'aac' },
+        ],
+        format: { duration: '85.0' },
+      }));
+      const blFile = path.join(tmpDir, 'baseline.json');
+      fs.writeFileSync(blFile, JSON.stringify(createBaseline(hash, size)));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('video codec');
+    });
+  });
+
+  describe('passes without ffprobe.json when no metadata cross-check needed', () => {
+    test('exits 0 when ffprobe.json is missing but hash matches', () => {
+      const artDir = path.join(tmpDir, 'art');
+      fs.mkdirSync(artDir, { recursive: true });
+      const mp4Data = Buffer.from('test-mp4-no-ffprobe');
+      fs.writeFileSync(path.join(artDir, 'preview.mp4'), mp4Data);
+      const hash = sha256(mp4Data);
+      const blFile = path.join(tmpDir, 'baseline.json');
+      // Baseline without expectedMedia
+      fs.writeFileSync(blFile, JSON.stringify({ _baselineVersion: 1, file: 'preview.mp4', sha256: hash, size: mp4Data.length }));
+      const result = runValidator(artDir, blFile);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('MP4 FINGERPRINT MATCHES BASELINE');
+    });
+  });
+});


### PR DESCRIPTION
Adds byte-level SHA-256 fingerprint validation for preview.mp4. Baseline from run 27828672285 (SHA-256: 183126452f9baee89ca3f63543e1c788352ca8db05b28d8e388a6a0e241895bb, size: 581180 bytes). Cross-checks media metadata from ffprobe.json. Local Jest: 46 suites, 440 tests, 439 passed, 1 skipped, 0 failed.