### PR TITLE
test: add automated full-flow tutorial smoke (fixture to MP4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,19 +96,61 @@ jobs:
           ffprobe -version | head -1
         shell: bash
 
+      - name: Cache FFmpeg static binaries (Windows)
+        if: runner.os == 'Windows'
+        id: ffmpeg-cache-win
+        uses: actions/cache@v4
+        with:
+          path: C:\ffmpeg
+          key: ffmpeg-n7.1.4-39-ga5faeca88f-win64-gpl
+
       - name: Ensure FFmpeg (Windows)
         if: runner.os == 'Windows'
         run: |
           Write-Host "--- FFmpeg setup (Windows) ---"
+          # Priority 1: already on PATH
           if (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
             Write-Host "source=preinstalled"
             ffmpeg -version | Select-Object -First 1
-          } else {
+          }
+          # Priority 2: common runner locations
+          elseif (Test-Path "C:\ProgramData\chocolatey\bin\ffmpeg.exe") {
+            Write-Host "source=choco-path"
+            echo "C:\ProgramData\chocolatey\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+            & "C:\ProgramData\chocolatey\bin\ffmpeg.exe" -version | Select-Object -First 1
+          }
+          # Priority 3: cached binaries from previous run
+          elseif (Test-Path "C:\ffmpeg\ffmpeg.exe") {
+            Write-Host "source=cache"
+            echo "C:\ffmpeg" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+            & "C:\ffmpeg\ffmpeg.exe" -version | Select-Object -First 1
+          }
+          # Priority 4: install via choco (reliable when community feed is up)
+          else {
             Write-Host "source=choco-install"
-            choco install ffmpeg -y --no-progress
-            refreshenv
-            $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH","User")
-            ffmpeg -version | Select-Object -First 1
+            choco install ffmpeg -y --no-progress --timeout=120
+            if ($LASTEXITCODE -eq 0) {
+              $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH","User")
+              echo "C:\ProgramData\chocolatey\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+            }
+            # Verify
+            if (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
+              ffmpeg -version | Select-Object -First 1
+            } else {
+              Write-Host "source=pinned-download-fallback"
+              $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-15-15-03/ffmpeg-n7.1.4-39-ga5faeca88f-win64-gpl-7.1.zip"
+              $zipPath = "$env:TEMP\ffmpeg.zip"
+              $extractPath = "$env:TEMP\ffmpeg-extract"
+              Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+              Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+              $binDir = (Get-ChildItem -Path $extractPath -Recurse -Filter "ffmpeg.exe" | Select-Object -First 1).DirectoryName
+              New-Item -ItemType Directory -Force -Path "C:\ffmpeg" | Out-Null
+              Copy-Item "$binDir\*" -Destination "C:\ffmpeg\" -Recurse -Force
+              echo "C:\ffmpeg" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+              Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+              Remove-Item $extractPath -Recurse -Force -ErrorAction SilentlyContinue
+              & "C:\ffmpeg\ffmpeg.exe" -version | Select-Object -First 1
+            }
           }
         shell: pwsh
 

--- a/tests/e2e/tutorial_full_flow_smoke.test.js
+++ b/tests/e2e/tutorial_full_flow_smoke.test.js
@@ -1,0 +1,201 @@
+/**
+ * Full-Flow Tutorial Smoke Test v1
+ *
+ * Proves the core tutorial pipeline can run end-to-end from a deterministic
+ * fixture to a rendered MP4, without manual Tutorial Preview Demo dispatch.
+ *
+ * Pipeline: fixture → script → storyboard → render-config → MP4 render → artifact validation
+ *
+ * Requires FFmpeg with drawtext filter. Skips gracefully on machines without FFmpeg.
+ */
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const GENERATE_SCRIPT = path.resolve(__dirname, '../../scripts/generate-tutorial-preview.mjs');
+const RENDER_SCRIPT = path.resolve(__dirname, '../../scripts/render-storyboard-ffmpeg.mjs');
+const VALIDATE_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial-preview-artifact.mjs');
+const FIXTURE = path.resolve(__dirname, '../fixtures/tutorial-vertical-slice/gem-collectors.json');
+
+// ---------------------------------------------------------------------------
+// FFmpeg availability detection (same pattern as storyboard_ffmpeg_real_mp4)
+// ---------------------------------------------------------------------------
+function isFfmpegAvailable() {
+  try {
+    execFileSync('ffmpeg', ['-version'], { stdio: 'pipe', timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isFfprobeAvailable() {
+  try {
+    execFileSync('ffprobe', ['-version'], { stdio: 'pipe', timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasDrawtextFilter() {
+  if (!isFfmpegAvailable()) return false;
+  try {
+    execFileSync('ffmpeg', [
+      '-hide_banner', '-loglevel', 'error',
+      '-f', 'lavfi', '-i', 'color=c=black:s=64x64:d=0.1',
+      '-vf', 'drawtext=text=X:fontsize=12',
+      '-frames:v', '1', '-f', 'null', '-',
+    ], { stdio: 'pipe', timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const CAN_RUN = isFfmpegAvailable() && isFfprobeAvailable() && hasDrawtextFilter();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mobius-full-flow-smoke-'));
+}
+
+function probeVideo(filePath) {
+  const raw = execFileSync('ffprobe', [
+    '-hide_banner', '-loglevel', 'error',
+    '-print_format', 'json',
+    '-show_format', '-show_streams',
+    filePath,
+  ], { encoding: 'utf8', stdio: 'pipe', timeout: 15000 });
+  return JSON.parse(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('Full-Flow Tutorial Smoke (fixture → MP4)', () => {
+  if (!CAN_RUN) {
+    test('SKIPPED: FFmpeg/ffprobe not available or missing drawtext filter', () => {
+      console.log('FFmpeg not found or drawtext filter unavailable — skipping full-flow smoke test.');
+      expect(true).toBe(true);
+    });
+    return;
+  }
+
+  let tmpDir;
+  let outDir;
+  let mp4Path;
+
+  beforeAll(() => {
+    tmpDir = createTempDir();
+    outDir = path.join(tmpDir, 'tutorial-preview');
+    mp4Path = path.join(outDir, 'preview.mp4');
+
+    // Step 1: Generate tutorial artifacts from fixture
+    execFileSync('node', [
+      GENERATE_SCRIPT,
+      '--fixture', FIXTURE,
+      '--slug', 'gem-collectors',
+      '--out', outDir,
+    ], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 30000,
+      cwd: path.resolve(__dirname, '../..'),
+    });
+
+    // Step 2: Render MP4 preview
+    execFileSync('node', [
+      RENDER_SCRIPT,
+      '--config', path.join(outDir, 'render-config.json'),
+      '--out', mp4Path,
+    ], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 120000,
+      cwd: path.resolve(__dirname, '../..'),
+    });
+  }, 180000);
+
+  afterAll(() => {
+    try {
+      if (tmpDir && fs.existsSync(tmpDir)) {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    } catch {}
+  });
+
+  test('preview.mp4 exists', () => {
+    expect(fs.existsSync(mp4Path)).toBe(true);
+  });
+
+  test('preview.mp4 is non-empty (> 10KB)', () => {
+    const stat = fs.statSync(mp4Path);
+    expect(stat.size).toBeGreaterThan(10240);
+  });
+
+  test('script.json exists', () => {
+    expect(fs.existsSync(path.join(outDir, 'script.json'))).toBe(true);
+  });
+
+  test('storyboard.json exists', () => {
+    expect(fs.existsSync(path.join(outDir, 'storyboard.json'))).toBe(true);
+  });
+
+  test('render-config.json exists', () => {
+    expect(fs.existsSync(path.join(outDir, 'render-config.json'))).toBe(true);
+  });
+
+  test('manifest.json exists', () => {
+    expect(fs.existsSync(path.join(outDir, 'manifest.json'))).toBe(true);
+  });
+
+  test('captions.srt exists', () => {
+    expect(fs.existsSync(path.join(outDir, 'captions.srt'))).toBe(true);
+  });
+
+  test('video has correct resolution (1920x1080)', () => {
+    const probe = probeVideo(mp4Path);
+    const videoStream = probe.streams.find((s) => s.codec_type === 'video');
+    expect(videoStream).toBeDefined();
+    expect(Number(videoStream.width)).toBe(1920);
+    expect(Number(videoStream.height)).toBe(1080);
+  });
+
+  test('video codec is H.264', () => {
+    const probe = probeVideo(mp4Path);
+    const videoStream = probe.streams.find((s) => s.codec_type === 'video');
+    expect(videoStream.codec_name).toBe('h264');
+  });
+
+  test('audio stream exists', () => {
+    const probe = probeVideo(mp4Path);
+    const audioStream = probe.streams.find((s) => s.codec_type === 'audio');
+    expect(audioStream).toBeDefined();
+  });
+
+  test('video duration is reasonable (60-120 seconds)', () => {
+    const probe = probeVideo(mp4Path);
+    const duration = Number(probe.format.duration);
+    expect(duration).toBeGreaterThan(60);
+    expect(duration).toBeLessThan(120);
+  });
+
+  test('artifact contract validator passes', () => {
+    const result = execFileSync('node', [
+      VALIDATE_SCRIPT,
+      '--dir', outDir,
+    ], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 15000,
+      cwd: path.resolve(__dirname, '../..'),
+    });
+    // Validator exits 0 on success
+    expect(result).toBeDefined();
+  });
+});

--- a/tests/e2e/tutorial_full_flow_smoke.test.js
+++ b/tests/e2e/tutorial_full_flow_smoke.test.js
@@ -86,6 +86,9 @@ describe('Full-Flow Tutorial Smoke (fixture → MP4)', () => {
     return;
   }
 
+  // Ensure sufficient timeout for CI rendering (~90s video)
+  jest.setTimeout(240000);
+
   let tmpDir;
   let outDir;
   let mp4Path;
@@ -119,7 +122,16 @@ describe('Full-Flow Tutorial Smoke (fixture → MP4)', () => {
       timeout: 120000,
       cwd: path.resolve(__dirname, '../..'),
     });
-  }, 180000);
+
+    // Step 3: Capture ffprobe.json (required by artifact validator)
+    const ffprobeOutput = execFileSync('ffprobe', [
+      '-hide_banner', '-loglevel', 'error',
+      '-print_format', 'json',
+      '-show_format', '-show_streams',
+      mp4Path,
+    ], { encoding: 'utf8', stdio: 'pipe', timeout: 15000 });
+    fs.writeFileSync(path.join(outDir, 'ffprobe.json'), ffprobeOutput, 'utf8');
+  }, 240000);
 
   afterAll(() => {
     try {
@@ -156,6 +168,10 @@ describe('Full-Flow Tutorial Smoke (fixture → MP4)', () => {
 
   test('captions.srt exists', () => {
     expect(fs.existsSync(path.join(outDir, 'captions.srt'))).toBe(true);
+  });
+
+  test('ffprobe.json exists', () => {
+    expect(fs.existsSync(path.join(outDir, 'ffprobe.json'))).toBe(true);
   });
 
   test('video has correct resolution (1920x1080)', () => {


### PR DESCRIPTION
## Summary Adds an automated end-to-end smoke test that proves the core tutorial pipeline can run from a deterministic fixture to a rendered MP4, without requiring manual Tutorial Preview Demo workflow dispatch. ## Pipeline Tested \\\ gem-collectors.json fixture → generate-tutorial-preview.mjs (script + storyboard + captions + render-config + manifest) → render-storyboard-ffmpeg.mjs (preview.mp4) → validate-tutorial-preview-artifact.mjs (artifact contract) \\\ ## Assertions - All 7 core artifacts generated (script, storyboard, captions, render-config, manifest, preview.mp4, ffprobe.json pending) - preview.mp4 exists and is > 10KB - H.264 video at 1920x1080 - Audio stream present - Duration 60–120s (expected ~85s) - Artifact contract validator passes ## Behavior - **With FFmpeg + drawtext**: Full pipeline runs end-to-end - **Without FFmpeg**: Test skips gracefully (same pattern as existing \storyboard_ffmpeg_real_mp4.test.js\) ## Testing - 48 local test suites pass (478 tests, 1 skipped on Windows without FFmpeg) - Awaiting CI validation where FFmpeg is available via hardened setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end smoke test for the tutorial workflow.
  * The test automatically skips when required video tools aren’t available.
  * It now verifies generated tutorial outputs, checks the rendered video’s format and quality, and confirms the final artifacts meet the expected contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->