### PR TITLE
feat: add real-input normalizer v1 — metadata + rulebook-extract to canonical fixture

### DIFF
--- a/scripts/normalize-real-input-fixture.cjs
+++ b/scripts/normalize-real-input-fixture.cjs
@@ -1,0 +1,87 @@
+/**
+ * normalize-real-input-fixture.cjs — CJS version of the normalizer.
+ * Used by Jest tests and other CJS consumers.
+ */
+
+'use strict';
+
+const { readFileSync, writeFileSync } = require('fs');
+const { resolve } = require('path');
+
+/**
+ * Convert product-like metadata + rulebook extraction into canonical tutorial fixture.
+ */
+function normalizeRealInput(metadata, extract) {
+  if (!metadata) throw new Error('normalizeRealInput: metadata is required');
+  if (!extract) throw new Error('normalizeRealInput: rulebook extract is required');
+  if (!metadata.slug) throw new Error('normalizeRealInput: metadata.slug is required');
+  if (!metadata.title) throw new Error('normalizeRealInput: metadata.title is required');
+  if (!metadata.playerCount) throw new Error('normalizeRealInput: metadata.playerCount is required');
+
+  if (!extract.objective) throw new Error('normalizeRealInput: extract.objective is required');
+  if (!Array.isArray(extract.components) || extract.components.length === 0) {
+    throw new Error('normalizeRealInput: extract.components must be a non-empty array');
+  }
+  if (!Array.isArray(extract.setup) || extract.setup.length === 0) {
+    throw new Error('normalizeRealInput: extract.setup must be a non-empty array');
+  }
+  if (!extract.turnStructure) throw new Error('normalizeRealInput: extract.turnStructure is required');
+  if (!extract.coreMechanic) throw new Error('normalizeRealInput: extract.coreMechanic is required');
+  if (!extract.scoring) throw new Error('normalizeRealInput: extract.scoring is required');
+
+  let duration;
+  if (metadata.playtimeMinutes) {
+    const { min, max } = metadata.playtimeMinutes;
+    duration = min === max ? `${min} minutes` : `${min}-${max} minutes`;
+  } else {
+    duration = 'Unknown';
+  }
+
+  const designer = Array.isArray(metadata.designers) && metadata.designers.length > 0
+    ? metadata.designers.join(', ')
+    : 'Unknown';
+
+  return {
+    gameId: metadata.slug,
+    gameName: metadata.title,
+    playerCount: metadata.playerCount,
+    duration,
+    designer,
+    objective: extract.objective,
+    components: extract.components,
+    setup: extract.setup,
+    turnStructure: extract.turnStructure,
+    coreMechanic: extract.coreMechanic,
+    scoring: extract.scoring,
+    edgeCases: extract.edgeCases || [],
+  };
+}
+
+module.exports = { normalizeRealInput };
+
+// CLI mode
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  function getArg(name) {
+    const idx = args.indexOf(`--${name}`);
+    if (idx === -1 || idx + 1 >= args.length) return null;
+    return args[idx + 1];
+  }
+
+  const metadataPath = getArg('metadata');
+  const extractPath = getArg('extract');
+  const outPath = getArg('out');
+
+  if (metadataPath && extractPath) {
+    const metadata = JSON.parse(readFileSync(resolve(metadataPath), 'utf8'));
+    const extract = JSON.parse(readFileSync(resolve(extractPath), 'utf8'));
+    const fixture = normalizeRealInput(metadata, extract);
+
+    if (outPath) {
+      writeFileSync(resolve(outPath), JSON.stringify(fixture, null, 2), 'utf8');
+      console.log(`[normalize] Written to: ${outPath}`);
+    } else {
+      console.log(JSON.stringify(fixture, null, 2));
+    }
+  }
+}

--- a/scripts/normalize-real-input-fixture.mjs
+++ b/scripts/normalize-real-input-fixture.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * normalize-real-input-fixture.mjs — Converts product-like metadata + rulebook-extract
+ * into the canonical tutorial fixture shape consumed by generate-tutorial-preview.mjs.
+ *
+ * Usage (CLI):
+ *   node scripts/normalize-real-input-fixture.mjs \
+ *     --metadata tests/fixtures/tutorial-real-input/sakura-market.metadata.json \
+ *     --extract tests/fixtures/tutorial-real-input/sakura-market.rulebook-extract.json \
+ *     --out /tmp/normalized-fixture.json
+ *
+ * Usage (import):
+ *   import { normalizeRealInput } from './normalize-real-input-fixture.mjs';
+ *   const fixture = normalizeRealInput(metadata, rulebookExtract);
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Normalizer function (importable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert product-like metadata + rulebook extraction into canonical tutorial fixture.
+ *
+ * @param {object} metadata - BGG-style normalized metadata
+ * @param {object} extract - Rulebook-extracted tutorial structure
+ * @returns {object} Canonical tutorial fixture JSON
+ */
+export function normalizeRealInput(metadata, extract) {
+  // Validate required metadata fields
+  if (!metadata) throw new Error('normalizeRealInput: metadata is required');
+  if (!extract) throw new Error('normalizeRealInput: rulebook extract is required');
+  if (!metadata.slug) throw new Error('normalizeRealInput: metadata.slug is required');
+  if (!metadata.title) throw new Error('normalizeRealInput: metadata.title is required');
+  if (!metadata.playerCount) throw new Error('normalizeRealInput: metadata.playerCount is required');
+
+  // Validate required extract fields
+  if (!extract.objective) throw new Error('normalizeRealInput: extract.objective is required');
+  if (!Array.isArray(extract.components) || extract.components.length === 0) {
+    throw new Error('normalizeRealInput: extract.components must be a non-empty array');
+  }
+  if (!Array.isArray(extract.setup) || extract.setup.length === 0) {
+    throw new Error('normalizeRealInput: extract.setup must be a non-empty array');
+  }
+  if (!extract.turnStructure) throw new Error('normalizeRealInput: extract.turnStructure is required');
+  if (!extract.coreMechanic) throw new Error('normalizeRealInput: extract.coreMechanic is required');
+  if (!extract.scoring) throw new Error('normalizeRealInput: extract.scoring is required');
+
+  // Format duration string
+  let duration;
+  if (metadata.playtimeMinutes) {
+    const { min, max } = metadata.playtimeMinutes;
+    duration = min === max ? `${min} minutes` : `${min}-${max} minutes`;
+  } else {
+    duration = 'Unknown';
+  }
+
+  // Format designer string
+  const designer = Array.isArray(metadata.designers) && metadata.designers.length > 0
+    ? metadata.designers.join(', ')
+    : 'Unknown';
+
+  return {
+    gameId: metadata.slug,
+    gameName: metadata.title,
+    playerCount: metadata.playerCount,
+    duration,
+    designer,
+    objective: extract.objective,
+    components: extract.components,
+    setup: extract.setup,
+    turnStructure: extract.turnStructure,
+    coreMechanic: extract.coreMechanic,
+    scoring: extract.scoring,
+    edgeCases: extract.edgeCases || [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI mode
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const metadataPath = getArg('metadata');
+const extractPath = getArg('extract');
+const outPath = getArg('out');
+
+if (metadataPath && extractPath) {
+  const metadata = JSON.parse(readFileSync(resolve(metadataPath), 'utf8'));
+  const extract = JSON.parse(readFileSync(resolve(extractPath), 'utf8'));
+
+  const fixture = normalizeRealInput(metadata, extract);
+
+  if (outPath) {
+    writeFileSync(resolve(outPath), JSON.stringify(fixture, null, 2), 'utf8');
+    console.log(`[normalize] Written to: ${outPath}`);
+  } else {
+    console.log(JSON.stringify(fixture, null, 2));
+  }
+}

--- a/tests/e2e/tutorial_full_flow_smoke.test.js
+++ b/tests/e2e/tutorial_full_flow_smoke.test.js
@@ -19,6 +19,9 @@ const RENDER_SCRIPT = path.resolve(__dirname, '../../scripts/render-storyboard-f
 const VALIDATE_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial-preview-artifact.mjs');
 const FIXTURE = path.resolve(__dirname, '../fixtures/tutorial-vertical-slice/gem-collectors.json');
 const REAL_INPUT_FIXTURE = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.json');
+const REAL_INPUT_METADATA = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.metadata.json');
+const REAL_INPUT_EXTRACT = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.rulebook-extract.json');
+const NORMALIZER_SCRIPT = path.resolve(__dirname, '../../scripts/normalize-real-input-fixture.cjs');
 
 // ---------------------------------------------------------------------------
 // FFmpeg availability detection (same pattern as storyboard_ffmpeg_real_mp4)
@@ -239,10 +242,24 @@ describe('Real-Input Smoke (sakura-market fixture → MP4)', () => {
     outDir = path.join(tmpDir, 'tutorial-preview-real');
     mp4Path = path.join(outDir, 'preview.mp4');
 
-    // Step 1: Generate tutorial artifacts from realistic fixture
+    // Step 0: Normalize metadata + rulebook-extract into canonical fixture
+    const normalizedFixturePath = path.join(tmpDir, 'sakura-market-normalized.json');
+    execFileSync('node', [
+      NORMALIZER_SCRIPT,
+      '--metadata', REAL_INPUT_METADATA,
+      '--extract', REAL_INPUT_EXTRACT,
+      '--out', normalizedFixturePath,
+    ], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 10000,
+      cwd: path.resolve(__dirname, '../..'),
+    });
+
+    // Step 1: Generate tutorial artifacts from normalized fixture
     execFileSync('node', [
       GENERATE_SCRIPT,
-      '--fixture', REAL_INPUT_FIXTURE,
+      '--fixture', normalizedFixturePath,
       '--slug', 'sakura-market',
       '--out', outDir,
     ], {

--- a/tests/fixtures/tutorial-real-input/sakura-market.expected.json
+++ b/tests/fixtures/tutorial-real-input/sakura-market.expected.json
@@ -1,0 +1,18 @@
+{
+  "_schema": "Expected contract assertions for normalized output",
+
+  "gameId": "sakura-market",
+  "gameName": "Sakura Market",
+  "minSegments": 8,
+  "maxSegments": 15,
+  "durationRange": { "min": 60, "max": 180 },
+  "requiredArtifacts": [
+    "script.json",
+    "storyboard.json",
+    "captions.srt",
+    "render-config.json",
+    "manifest.json",
+    "preview.mp4",
+    "ffprobe.json"
+  ]
+}

--- a/tests/fixtures/tutorial-real-input/sakura-market.metadata.json
+++ b/tests/fixtures/tutorial-real-input/sakura-market.metadata.json
@@ -1,0 +1,18 @@
+{
+  "_schema": "BGG-style normalized game metadata",
+  "_source": "Offline fixture — no live BGG fetch",
+
+  "bggId": null,
+  "slug": "sakura-market",
+  "title": "Sakura Market",
+  "yearPublished": 2024,
+  "designers": ["Offline Fixture Author"],
+  "publishers": ["Offline Fixture Publisher"],
+  "playerCount": { "min": 2, "max": 5 },
+  "playtimeMinutes": { "min": 30, "max": 45 },
+  "recommendedAge": 10,
+  "categories": ["Economic", "Market"],
+  "mechanics": ["Set Collection", "Dice Rolling", "Market Timing"],
+  "weight": 2.3,
+  "description": "Become the most successful merchant by buying and selling goods at the seasonal market. Balance risk and timing to maximize your profit before the festival ends."
+}

--- a/tests/fixtures/tutorial-real-input/sakura-market.rulebook-extract.json
+++ b/tests/fixtures/tutorial-real-input/sakura-market.rulebook-extract.json
@@ -1,0 +1,50 @@
+{
+  "_schema": "Rulebook-extracted tutorial structure",
+  "_source": "Offline fixture — no PDF extraction or OCR",
+  "_confidence": "high",
+
+  "objective": "Become the most successful merchant by buying and selling goods at the seasonal market. Balance risk and timing to maximize your profit before the festival ends.",
+
+  "components": [
+    { "name": "Goods cards", "quantity": 80, "category": "cards" },
+    { "name": "Market tiles", "quantity": 12, "category": "tiles" },
+    { "name": "Coin tokens", "quantity": 60, "category": "tokens" },
+    { "name": "Festival track board", "quantity": 1, "category": "board" },
+    { "name": "Merchant pawns", "quantity": 5, "category": "pawns" },
+    { "name": "Season marker", "quantity": 1, "category": "tokens" },
+    { "name": "Price dice", "quantity": 3, "category": "dice" }
+  ],
+
+  "setup": [
+    "Place the festival track board in the center of the table and set the season marker on the first space.",
+    "Shuffle all 80 goods cards and deal 5 to each player as their starting hand.",
+    "Place the remaining goods cards face-down as the supply deck.",
+    "Arrange the 12 market tiles in a circle around the festival track to form the market ring.",
+    "Give each player 8 coin tokens and one merchant pawn in their chosen color.",
+    "Roll the 3 price dice and place them on the corresponding market tiles to set initial prices.",
+    "The player who most recently visited a farmers market goes first."
+  ],
+
+  "turnStructure": {
+    "phases": ["Move", "Trade", "Refresh"],
+    "description": "On your turn: Move your merchant pawn 1-3 spaces around the market ring. Then Trade by buying goods from your current tile at the posted price or selling goods you hold for coins. Finally, Refresh by drawing one card from the supply deck and re-rolling one price die.",
+    "endCondition": "The game ends when the season marker reaches the festival space. This happens after a full round where the supply deck runs out."
+  },
+
+  "coreMechanic": {
+    "name": "Market Timing",
+    "description": "Prices fluctuate each turn as dice are re-rolled. Buy goods when prices are low and sell when prices are high. Your movement around the market ring determines which goods you can access, creating tension between optimal positioning and timing."
+  },
+
+  "scoring": {
+    "description": "At game end, count all your coins. Each unsold goods card in hand is worth 1 coin regardless of market price. Bonus: the player with the most diverse goods collection (one of each type) earns 10 bonus coins.",
+    "winCondition": "The player with the most coins wins. Ties broken by most goods cards remaining in hand."
+  },
+
+  "edgeCases": [
+    "If the supply deck runs out mid-round, complete the current round and then advance the season marker to the festival space immediately.",
+    "If a price die shows the same value as another die already on the market ring, the player may choose any unoccupied tile for it.",
+    "A player may pass their Trade phase without buying or selling.",
+    "If a player cannot move because all adjacent tiles are occupied by other merchants, they may teleport to any empty tile but forfeit their Trade phase."
+  ]
+}

--- a/tests/scripts/normalizeRealInputFixture.test.js
+++ b/tests/scripts/normalizeRealInputFixture.test.js
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for normalize-real-input-fixture
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { normalizeRealInput } = require('../../scripts/normalize-real-input-fixture.cjs');
+
+const METADATA_PATH = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.metadata.json');
+const EXTRACT_PATH = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.rulebook-extract.json');
+
+function loadMetadata() {
+  return JSON.parse(fs.readFileSync(METADATA_PATH, 'utf8'));
+}
+
+function loadExtract() {
+  return JSON.parse(fs.readFileSync(EXTRACT_PATH, 'utf8'));
+}
+
+describe('normalizeRealInput', () => {
+  test('produces canonical fixture with correct gameId and gameName', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.gameId).toBe('sakura-market');
+    expect(result.gameName).toBe('Sakura Market');
+  });
+
+  test('maps player count from metadata', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.playerCount).toEqual({ min: 2, max: 5 });
+  });
+
+  test('formats duration from playtime range', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.duration).toBe('30-45 minutes');
+  });
+
+  test('formats designer from designers array', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.designer).toBe('Offline Fixture Author');
+  });
+
+  test('preserves objective from extract', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.objective).toContain('merchant');
+  });
+
+  test('preserves components array', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.components).toHaveLength(7);
+    expect(result.components[0].name).toBe('Goods cards');
+  });
+
+  test('preserves setup array', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.setup).toHaveLength(7);
+  });
+
+  test('preserves turn structure', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.turnStructure.phases).toEqual(['Move', 'Trade', 'Refresh']);
+  });
+
+  test('preserves core mechanic', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.coreMechanic.name).toBe('Market Timing');
+  });
+
+  test('preserves scoring', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.scoring.winCondition).toContain('most coins');
+  });
+
+  test('preserves edge cases', () => {
+    const result = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(result.edgeCases).toHaveLength(4);
+  });
+
+  test('output is deterministic across repeated calls', () => {
+    const a = normalizeRealInput(loadMetadata(), loadExtract());
+    const b = normalizeRealInput(loadMetadata(), loadExtract());
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  test('throws on missing metadata', () => {
+    expect(() => normalizeRealInput(null, loadExtract())).toThrow('metadata is required');
+  });
+
+  test('throws on missing extract', () => {
+    expect(() => normalizeRealInput(loadMetadata(), null)).toThrow('rulebook extract is required');
+  });
+
+  test('throws on missing metadata.slug', () => {
+    const meta = loadMetadata();
+    delete meta.slug;
+    expect(() => normalizeRealInput(meta, loadExtract())).toThrow('metadata.slug is required');
+  });
+
+  test('throws on missing extract.objective', () => {
+    const ext = loadExtract();
+    delete ext.objective;
+    expect(() => normalizeRealInput(loadMetadata(), ext)).toThrow('extract.objective is required');
+  });
+
+  test('throws on empty components', () => {
+    const ext = loadExtract();
+    ext.components = [];
+    expect(() => normalizeRealInput(loadMetadata(), ext)).toThrow('non-empty array');
+  });
+});


### PR DESCRIPTION
## Summary Adds a deterministic normalizer that converts product-like input layers (BGG-style metadata + rulebook-extracted structure) into the canonical tutorial fixture shape consumed by the existing generation pipeline. ## What's New - **Split fixtures**: \sakura-market.metadata.json\ + \sakura-market.rulebook-extract.json\ + \sakura-market.expected.json\ - **Normalizer**: \scripts/normalize-real-input-fixture.cjs\ (+ ESM variant) — converts layered input into canonical shape - **17 unit tests**: Required field mapping, deterministic output, error handling for missing fields - **Updated e2e smoke**: Real-input path now calls the normalizer before generation, proving the full product-like pipeline ## Pipeline Proven \\\ sakura-market.metadata.json + sakura-market.rulebook-extract.json → normalize-real-input-fixture.cjs (canonical fixture) → generate-tutorial-preview.mjs (script + storyboard + captions + render-config + manifest) → render-storyboard-ffmpeg.mjs (preview.mp4) → ffprobe (ffprobe.json) → artifact file assertions \\\ ## Testing - 49 local test suites pass (496 tests, 1 skipped on Windows without FFmpeg) - 17 normalizer unit tests covering field mapping, determinism, and validation - Awaiting CI validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for normalizing real game metadata and extracted rulebook content into a consistent fixture format.
  * Added CLI support to generate normalized output from input JSON files.

* **Bug Fixes**
  * Improved validation for required fields and clearer handling of missing or incomplete input data.
  * Standardized fallback values for unknown duration and designer details.

* **Tests**
  * Added unit coverage for normalization behavior, deterministic output, and validation failures.
  * Updated end-to-end smoke flow to use the new normalized real-input fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->