### PR TITLE
feat: real-input artifact contract validator v1

### DIFF
--- a/scripts/validate-real-input-preview-artifact.cjs
+++ b/scripts/validate-real-input-preview-artifact.cjs
@@ -1,0 +1,138 @@
+/**
+ * validate-real-input-preview-artifact.cjs — CJS version of the validator.
+ * Used by Jest tests and other CJS consumers.
+ *
+ * Validates a real-input artifact directory against an expected-contract JSON object.
+ */
+
+'use strict';
+
+const { existsSync, readFileSync, statSync } = require('fs');
+const { join } = require('path');
+
+/**
+ * Validate an artifact directory against an expected contract.
+ * @param {string} artifactDir - Absolute path to artifact directory.
+ * @param {object} contract - Parsed expected-contract object.
+ * @returns {{ passed: boolean, errors: string[] }}
+ */
+function validateRealInputArtifact(artifactDir, contract) {
+  const errors = [];
+
+  function fail(msg) {
+    errors.push(msg);
+  }
+
+  // -------------------------------------------------------------------------
+  // Required artifacts existence + non-empty
+  // -------------------------------------------------------------------------
+  const requiredArtifacts = contract.requiredArtifacts || [];
+  for (const file of requiredArtifacts) {
+    const filePath = join(artifactDir, file);
+    if (!existsSync(filePath)) {
+      fail(`Missing required artifact: ${file}`);
+      continue;
+    }
+    const stat = statSync(filePath);
+    if (stat.size === 0) {
+      fail(`Artifact is empty (0 bytes): ${file}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // MP4 minimum size
+  // -------------------------------------------------------------------------
+  const minMp4Bytes = contract.minMp4Bytes || 10240;
+  const mp4Path = join(artifactDir, 'preview.mp4');
+  if (existsSync(mp4Path)) {
+    const mp4Stat = statSync(mp4Path);
+    if (mp4Stat.size < minMp4Bytes) {
+      fail(`preview.mp4 is ${mp4Stat.size} bytes, expected at least ${minMp4Bytes}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // manifest.json identity checks
+  // -------------------------------------------------------------------------
+  const manifestPath = join(artifactDir, 'manifest.json');
+  if (existsSync(manifestPath)) {
+    let manifest;
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    } catch (err) {
+      fail(`manifest.json: invalid JSON — ${err.message}`);
+    }
+    if (manifest && contract.manifest) {
+      if (contract.manifest.gameId && manifest.game?.id !== contract.manifest.gameId) {
+        fail(`manifest.json: game.id is "${manifest.game?.id}", expected "${contract.manifest.gameId}"`);
+      }
+      if (contract.manifest.gameName && manifest.game?.name !== contract.manifest.gameName) {
+        fail(`manifest.json: game.name is "${manifest.game?.name}", expected "${contract.manifest.gameName}"`);
+      }
+      if (contract.manifest.fixtureSlug && manifest.fixtureSlug !== contract.manifest.fixtureSlug) {
+        fail(`manifest.json: fixtureSlug is "${manifest.fixtureSlug}", expected "${contract.manifest.fixtureSlug}"`);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // ffprobe.json media contract
+  // -------------------------------------------------------------------------
+  const ffprobePath = join(artifactDir, 'ffprobe.json');
+  if (existsSync(ffprobePath)) {
+    let ffprobe;
+    try {
+      ffprobe = JSON.parse(readFileSync(ffprobePath, 'utf8'));
+    } catch (err) {
+      fail(`ffprobe.json: invalid JSON — ${err.message}`);
+    }
+
+    if (ffprobe) {
+      const streams = ffprobe.streams || [];
+      const videoStream = streams.find((s) => s.codec_type === 'video');
+      const audioStream = streams.find((s) => s.codec_type === 'audio');
+
+      // Video stream checks
+      if (contract.media?.video) {
+        if (!videoStream) {
+          fail('ffprobe.json: no video stream found');
+        } else {
+          const expectedCodec = contract.media.video.codec;
+          if (expectedCodec && videoStream.codec_name !== expectedCodec) {
+            fail(`ffprobe.json: video codec is "${videoStream.codec_name}", expected "${expectedCodec}"`);
+          }
+          const expectedWidth = contract.media.video.width;
+          if (expectedWidth && Number(videoStream.width) !== expectedWidth) {
+            fail(`ffprobe.json: video width is ${videoStream.width}, expected ${expectedWidth}`);
+          }
+          const expectedHeight = contract.media.video.height;
+          if (expectedHeight && Number(videoStream.height) !== expectedHeight) {
+            fail(`ffprobe.json: video height is ${videoStream.height}, expected ${expectedHeight}`);
+          }
+        }
+      }
+
+      // Audio stream checks
+      if (contract.media?.audio?.required) {
+        if (!audioStream) {
+          fail('ffprobe.json: no audio stream found (audio required by contract)');
+        }
+      }
+
+      // Duration range checks
+      if (contract.durationRange) {
+        const duration = parseFloat(ffprobe.format?.duration || '0');
+        if (duration < contract.durationRange.min) {
+          fail(`ffprobe.json: duration is ${duration}s, expected at least ${contract.durationRange.min}s`);
+        }
+        if (duration > contract.durationRange.max) {
+          fail(`ffprobe.json: duration is ${duration}s, expected at most ${contract.durationRange.max}s`);
+        }
+      }
+    }
+  }
+
+  return { passed: errors.length === 0, errors };
+}
+
+module.exports = { validateRealInputArtifact };

--- a/scripts/validate-real-input-preview-artifact.mjs
+++ b/scripts/validate-real-input-preview-artifact.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+/**
+ * validate-real-input-preview-artifact.mjs — Contract validator for real-input artifacts.
+ *
+ * Unlike the deterministic preview validator (validate-tutorial-preview-artifact.mjs)
+ * which uses hardcoded duration/content thresholds calibrated to golden baselines,
+ * this validator is driven by an external expected-contract JSON file.
+ *
+ * Usage:
+ *   node scripts/validate-real-input-preview-artifact.mjs --dir <artifact-dir> --expected <expected-json>
+ *
+ * Exit codes:
+ *   0 = all checks pass
+ *   1 = one or more contract violations found
+ *   2 = invalid arguments or missing expected JSON
+ */
+
+import { createRequire } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { validateRealInputArtifact } = require('./validate-real-input-preview-artifact.cjs');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const dir = getArg('dir');
+const expectedPath = getArg('expected');
+
+if (!dir || !expectedPath) {
+  console.error('Usage: node scripts/validate-real-input-preview-artifact.mjs --dir <artifact-dir> --expected <expected-json>');
+  process.exit(2);
+}
+
+const resolvedDir = resolve(dir);
+const resolvedExpected = resolve(expectedPath);
+
+if (!existsSync(resolvedExpected)) {
+  console.error(`[validate-real-input] Expected contract file not found: ${resolvedExpected}`);
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Load expected contract
+// ---------------------------------------------------------------------------
+let expected;
+try {
+  expected = JSON.parse(readFileSync(resolvedExpected, 'utf8'));
+} catch (err) {
+  console.error(`[validate-real-input] Failed to parse expected contract JSON: ${err.message}`);
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// CLI execution
+// ---------------------------------------------------------------------------
+console.log(`[validate-real-input] Artifact directory: ${resolvedDir}`);
+console.log(`[validate-real-input] Expected contract: ${resolvedExpected}`);
+console.log('[validate-real-input] Running contract checks...');
+
+const result = validateRealInputArtifact(resolvedDir, expected);
+
+console.log('');
+if (result.passed) {
+  const artifactCount = (expected.requiredArtifacts || []).length;
+  console.log(`[validate-real-input] ALL CHECKS PASSED (${artifactCount} artifacts, media contract, identity contract)`);
+  process.exit(0);
+} else {
+  console.error(`[validate-real-input] FAILED: ${result.errors.length} contract violation(s):`);
+  result.errors.forEach((e) => console.error(`  - ${e}`));
+  process.exit(1);
+}

--- a/tests/e2e/tutorial_full_flow_smoke.test.js
+++ b/tests/e2e/tutorial_full_flow_smoke.test.js
@@ -17,6 +17,8 @@ const os = require('os');
 const GENERATE_SCRIPT = path.resolve(__dirname, '../../scripts/generate-tutorial-preview.mjs');
 const RENDER_SCRIPT = path.resolve(__dirname, '../../scripts/render-storyboard-ffmpeg.mjs');
 const VALIDATE_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial-preview-artifact.mjs');
+const VALIDATE_REAL_INPUT_SCRIPT = path.resolve(__dirname, '../../scripts/validate-real-input-preview-artifact.mjs');
+const REAL_INPUT_EXPECTED = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.expected.json');
 const FIXTURE = path.resolve(__dirname, '../fixtures/tutorial-vertical-slice/gem-collectors.json');
 const REAL_INPUT_FIXTURE = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.json');
 const REAL_INPUT_METADATA = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.metadata.json');
@@ -344,16 +346,21 @@ describe('Real-Input Smoke (sakura-market fixture → MP4)', () => {
     expect(duration).toBeLessThan(180);
   });
 
-  test('artifact contract core files exist and are non-empty', () => {
-    // Note: We do NOT call validate-tutorial-preview-artifact.mjs here because
-    // it enforces duration 80-90s (calibrated for gem-collectors/hanamikoji baselines).
-    // The real-input fixture intentionally produces longer content (~118s).
-    // Instead we directly verify all required files exist and are non-empty.
-    const REQUIRED = ['preview.mp4', 'script.json', 'storyboard.json', 'captions.srt', 'render-config.json', 'manifest.json', 'ffprobe.json'];
-    for (const file of REQUIRED) {
-      const filePath = path.join(outDir, file);
-      expect(fs.existsSync(filePath)).toBe(true);
-      expect(fs.statSync(filePath).size).toBeGreaterThan(0);
-    }
+  test('real-input artifact contract validator passes', () => {
+    // Uses the contract-driven validator (validate-real-input-preview-artifact.mjs)
+    // instead of the deterministic validator (validate-tutorial-preview-artifact.mjs)
+    // which enforces 80-90s duration calibrated for gem-collectors/hanamikoji baselines.
+    const result = execFileSync('node', [
+      VALIDATE_REAL_INPUT_SCRIPT,
+      '--dir', outDir,
+      '--expected', REAL_INPUT_EXPECTED,
+    ], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 15000,
+      cwd: path.resolve(__dirname, '../..'),
+    });
+    // Validator exits 0 on success; any contract violation exits 1
+    expect(result).toContain('ALL CHECKS PASSED');
   });
 });

--- a/tests/fixtures/tutorial-real-input/README.md
+++ b/tests/fixtures/tutorial-real-input/README.md
@@ -31,7 +31,53 @@ Each fixture simulates the output of a two-layer ingestion process:
 |------|------|-------------|
 | `sakura-market` | Sakura Market | Fictional market-timing board game with rich components, multi-phase turns, and dice-driven price fluctuation |
 
+## File Layout
+
+Each fixture consists of layered input files and a contract:
+
+| File | Role |
+|------|------|
+| `<slug>.metadata.json` | Simulated BGG metadata (game name, player count, playtime, designers) |
+| `<slug>.rulebook-extract.json` | Structured rulebook extraction (objective, components, setup, turns, scoring) |
+| `<slug>.expected.json` | Artifact contract — expected validation assertions for rendered output |
+
 ## Usage
 
-These fixtures use the same JSON schema as `tests/fixtures/tutorial-vertical-slice/`
-and can be consumed directly by `scripts/generate-tutorial-preview.mjs`.
+### Normalizer path (preferred)
+
+```bash
+node scripts/normalize-real-input-fixture.cjs \
+  --metadata tests/fixtures/tutorial-real-input/sakura-market.metadata.json \
+  --extract tests/fixtures/tutorial-real-input/sakura-market.rulebook-extract.json \
+  --out /tmp/sakura-market.json
+```
+
+The normalizer produces a canonical tutorial fixture consumed by
+`scripts/generate-tutorial-preview.mjs`.
+
+### Artifact contract validation
+
+After rendering, validate artifacts against the expected contract:
+
+```bash
+node scripts/validate-real-input-preview-artifact.mjs \
+  --dir <artifact-output-dir> \
+  --expected tests/fixtures/tutorial-real-input/sakura-market.expected.json
+```
+
+The contract validator checks:
+- All required artifacts exist and are non-empty
+- `preview.mp4` exceeds minimum size threshold
+- `manifest.json` references the correct game identity (gameId, gameName, fixtureSlug)
+- `ffprobe.json` confirms video codec, resolution, audio presence, and duration range
+
+## How This Differs from Golden Preview Validation
+
+| Aspect | Golden validator | Real-input contract validator |
+|--------|-----------------|-------------------------------|
+| Script | `validate-tutorial-preview-artifact.mjs` | `validate-real-input-preview-artifact.mjs` |
+| Duration | Hardcoded 80-90s (gem-collectors/hanamikoji baselines) | Configurable via `durationRange` in `expected.json` |
+| Identity | Optional `--slug` flag | Required `manifest` block in contract |
+| Media | Hardcoded H.264/1920x1080/30fps/AAC | Configurable per-contract |
+| Content | Validates script segments, storyboard scenes, captions cue count | Focuses on artifact existence and media properties |
+| Use case | Deterministic golden baseline comparison | Realistic variable-length content validation |

--- a/tests/fixtures/tutorial-real-input/sakura-market.expected.json
+++ b/tests/fixtures/tutorial-real-input/sakura-market.expected.json
@@ -1,11 +1,12 @@
 {
-  "_schema": "Expected contract assertions for normalized output",
+  "_schema": "Real-input artifact contract — expected assertions for validated output",
 
   "gameId": "sakura-market",
   "gameName": "Sakura Market",
-  "minSegments": 8,
-  "maxSegments": 15,
+  "fixtureSlug": "sakura-market",
+
   "durationRange": { "min": 60, "max": 180 },
+
   "requiredArtifacts": [
     "script.json",
     "storyboard.json",
@@ -14,5 +15,24 @@
     "manifest.json",
     "preview.mp4",
     "ffprobe.json"
-  ]
+  ],
+
+  "media": {
+    "video": {
+      "codec": "h264",
+      "width": 1920,
+      "height": 1080
+    },
+    "audio": {
+      "required": true
+    }
+  },
+
+  "manifest": {
+    "gameId": "sakura-market",
+    "gameName": "Sakura Market",
+    "fixtureSlug": "sakura-market"
+  },
+
+  "minMp4Bytes": 10240
 }

--- a/tests/scripts/validateRealInputPreviewArtifact.test.js
+++ b/tests/scripts/validateRealInputPreviewArtifact.test.js
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for validate-real-input-preview-artifact
+ *
+ * Tests the validateRealInputArtifact function with synthetic artifact
+ * directories to verify pass/fail behavior against expected contracts.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { validateRealInputArtifact } = require('../../scripts/validate-real-input-preview-artifact.cjs');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mobius-validator-test-'));
+}
+
+function writeFile(dir, name, content) {
+  fs.writeFileSync(path.join(dir, name), content, 'utf8');
+}
+
+function writeBinary(dir, name, sizeBytes) {
+  const buf = Buffer.alloc(sizeBytes, 0x42);
+  fs.writeFileSync(path.join(dir, name), buf);
+}
+
+/**
+ * Build a minimal valid artifact set that passes all contract checks.
+ */
+function buildValidArtifacts(dir, overrides = {}) {
+  const gameId = overrides.gameId || 'sakura-market';
+  const gameName = overrides.gameName || 'Sakura Market';
+  const fixtureSlug = overrides.fixtureSlug || 'sakura-market';
+  const duration = overrides.duration || '120.5';
+  const videoCodec = overrides.videoCodec || 'h264';
+  const width = overrides.width || 1920;
+  const height = overrides.height || 1080;
+  const includeAudio = overrides.includeAudio !== false;
+  const mp4Size = overrides.mp4Size || 20000;
+
+  // preview.mp4
+  writeBinary(dir, 'preview.mp4', mp4Size);
+
+  // script.json
+  writeFile(dir, 'script.json', JSON.stringify({ segments: [{ id: '1', narration: 'test', durationSec: 5 }] }));
+
+  // storyboard.json
+  writeFile(dir, 'storyboard.json', JSON.stringify({ scenes: [{ id: '1', durationSec: 5 }] }));
+
+  // captions.srt
+  writeFile(dir, 'captions.srt', '1\n00:00:00,000 --> 00:00:05,000\nTest caption\n');
+
+  // render-config.json
+  writeFile(dir, 'render-config.json', JSON.stringify({ projectId: 'test', scenes: [{}] }));
+
+  // manifest.json
+  writeFile(dir, 'manifest.json', JSON.stringify({
+    generatedAt: new Date().toISOString(),
+    game: { id: gameId, name: gameName },
+    fixtureSlug,
+    script: {},
+    storyboard: {},
+    captions: {},
+    render: {},
+  }));
+
+  // ffprobe.json
+  const streams = [
+    { codec_type: 'video', codec_name: videoCodec, width, height, r_frame_rate: '30/1' },
+  ];
+  if (includeAudio) {
+    streams.push({ codec_type: 'audio', codec_name: 'aac' });
+  }
+  writeFile(dir, 'ffprobe.json', JSON.stringify({
+    streams,
+    format: { duration },
+  }));
+}
+
+/**
+ * Minimal valid contract matching buildValidArtifacts defaults.
+ */
+function buildContract(overrides = {}) {
+  return {
+    gameId: 'sakura-market',
+    gameName: 'Sakura Market',
+    fixtureSlug: 'sakura-market',
+    durationRange: { min: 60, max: 180 },
+    requiredArtifacts: [
+      'script.json',
+      'storyboard.json',
+      'captions.srt',
+      'render-config.json',
+      'manifest.json',
+      'preview.mp4',
+      'ffprobe.json',
+    ],
+    media: {
+      video: { codec: 'h264', width: 1920, height: 1080 },
+      audio: { required: true },
+    },
+    manifest: {
+      gameId: 'sakura-market',
+      gameName: 'Sakura Market',
+      fixtureSlug: 'sakura-market',
+    },
+    minMp4Bytes: 10240,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('validateRealInputArtifact', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  test('passes with a minimal valid artifact set', () => {
+    buildValidArtifacts(tmpDir);
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('fails when a required file is missing', () => {
+    buildValidArtifacts(tmpDir);
+    fs.unlinkSync(path.join(tmpDir, 'captions.srt'));
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('captions.srt'))).toBe(true);
+  });
+
+  test('fails when a required file is empty', () => {
+    buildValidArtifacts(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'script.json'), '');
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('script.json') && e.includes('empty'))).toBe(true);
+  });
+
+  test('fails when manifest has wrong gameId', () => {
+    buildValidArtifacts(tmpDir, { gameId: 'wrong-game' });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('game.id') && e.includes('wrong-game'))).toBe(true);
+  });
+
+  test('fails when manifest has wrong gameName', () => {
+    buildValidArtifacts(tmpDir, { gameName: 'Wrong Name' });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('game.name') && e.includes('Wrong Name'))).toBe(true);
+  });
+
+  test('fails when manifest has wrong fixtureSlug', () => {
+    buildValidArtifacts(tmpDir, { fixtureSlug: 'wrong-slug' });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('fixtureSlug') && e.includes('wrong-slug'))).toBe(true);
+  });
+
+  test('fails when duration is below min', () => {
+    buildValidArtifacts(tmpDir, { duration: '30.0' });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('duration') && e.includes('30'))).toBe(true);
+  });
+
+  test('fails when duration is above max', () => {
+    buildValidArtifacts(tmpDir, { duration: '250.0' });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('duration') && e.includes('250'))).toBe(true);
+  });
+
+  test('fails when audio stream is missing and audio is required', () => {
+    buildValidArtifacts(tmpDir, { includeAudio: false });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('audio') && e.includes('required'))).toBe(true);
+  });
+
+  test('passes when audio stream is missing but audio is not required', () => {
+    buildValidArtifacts(tmpDir, { includeAudio: false });
+    const contract = buildContract({ media: { video: { codec: 'h264', width: 1920, height: 1080 }, audio: { required: false } } });
+    const result = validateRealInputArtifact(tmpDir, contract);
+    expect(result.passed).toBe(true);
+  });
+
+  test('fails when video resolution is wrong', () => {
+    buildValidArtifacts(tmpDir, { width: 1280, height: 720 });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('width') && e.includes('1280'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('height') && e.includes('720'))).toBe(true);
+  });
+
+  test('fails when video codec is wrong', () => {
+    buildValidArtifacts(tmpDir, { videoCodec: 'hevc' });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('video codec') && e.includes('hevc'))).toBe(true);
+  });
+
+  test('fails when ffprobe.json is malformed', () => {
+    buildValidArtifacts(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'ffprobe.json'), 'not json at all');
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('ffprobe.json') && e.includes('invalid JSON'))).toBe(true);
+  });
+
+  test('fails when manifest.json is malformed', () => {
+    buildValidArtifacts(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'manifest.json'), '{broken');
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('manifest.json') && e.includes('invalid JSON'))).toBe(true);
+  });
+
+  test('fails when preview.mp4 is below minimum size', () => {
+    buildValidArtifacts(tmpDir, { mp4Size: 100 });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('preview.mp4') && e.includes('100'))).toBe(true);
+  });
+
+  test('reports multiple errors simultaneously', () => {
+    buildValidArtifacts(tmpDir, { gameId: 'wrong', duration: '10.0', includeAudio: false });
+    const result = validateRealInputArtifact(tmpDir, buildContract());
+    expect(result.passed).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('passes with contract that has no media checks', () => {
+    buildValidArtifacts(tmpDir);
+    const contract = buildContract({ media: undefined });
+    const result = validateRealInputArtifact(tmpDir, contract);
+    expect(result.passed).toBe(true);
+  });
+
+  test('passes with contract that has no duration range', () => {
+    buildValidArtifacts(tmpDir, { duration: '5.0' });
+    const contract = buildContract({ durationRange: undefined });
+    const result = validateRealInputArtifact(tmpDir, contract);
+    expect(result.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary Adds a reusable, contract-driven artifact validator for real-input (product-like) tutorial smoke outputs. Replaces ad-hoc inline assertions with a formal validator driven by sakura-market.expected.json. ## Changes - **scripts/validate-real-input-preview-artifact.{cjs,mjs}** — New contract validator (CJS for testability, ESM for CLI). Checks: - Required artifacts exist and are non-empty - preview.mp4 exceeds minimum size threshold - manifest.json references correct game identity (gameId, gameName, fixtureSlug) - fprobe.json confirms video codec, resolution, audio presence, and duration range - **	ests/fixtures/tutorial-real-input/sakura-market.expected.json** — Expanded with full contract fields (media, manifest identity, minMp4Bytes) - **	ests/scripts/validateRealInputPreviewArtifact.test.js** — 18 unit tests covering pass/fail behavior - **	ests/e2e/tutorial_full_flow_smoke.test.js** — Real-input smoke now calls contract validator instead of inline assertions - **	ests/fixtures/tutorial-real-input/README.md** — Documents contract validator usage and comparison with golden validator ## What stays unchanged - Deterministic golden preview validator (alidate-tutorial-preview-artifact.mjs) - Golden baselines and golden checks workflow - Renderer logic - Normalizer logic ## Testing - 18 unit tests pass locally - Full local suite (49 suites, 512 tests) passes with 0 failures - E2e smoke exercises validator via CI (FFmpeg-dependent)