### PR TITLE
feat: real-input fixture registry and auto-discovery v1

### DIFF
--- a/tests/e2e/tutorial_full_flow_smoke.test.js
+++ b/tests/e2e/tutorial_full_flow_smoke.test.js
@@ -22,26 +22,21 @@ const FIXTURE = path.resolve(__dirname, '../fixtures/tutorial-vertical-slice/gem
 const NORMALIZER_SCRIPT = path.resolve(__dirname, '../../scripts/normalize-real-input-fixture.cjs');
 
 // ---------------------------------------------------------------------------
-// Real-input fixture matrix
+// Real-input fixture matrix (loaded from registry)
 // ---------------------------------------------------------------------------
 const REAL_INPUT_DIR = path.resolve(__dirname, '../fixtures/tutorial-real-input');
+const REGISTRY_PATH = path.join(REAL_INPUT_DIR, 'fixtures.json');
 
-const REAL_INPUT_MATRIX = [
-  {
-    slug: 'sakura-market',
-    gameName: 'Sakura Market',
-    metadata: path.join(REAL_INPUT_DIR, 'sakura-market.metadata.json'),
-    extract: path.join(REAL_INPUT_DIR, 'sakura-market.rulebook-extract.json'),
-    expected: path.join(REAL_INPUT_DIR, 'sakura-market.expected.json'),
-  },
-  {
-    slug: 'stellar-drift',
-    gameName: 'Stellar Drift',
-    metadata: path.join(REAL_INPUT_DIR, 'stellar-drift.metadata.json'),
-    extract: path.join(REAL_INPUT_DIR, 'stellar-drift.rulebook-extract.json'),
-    expected: path.join(REAL_INPUT_DIR, 'stellar-drift.expected.json'),
-  },
-];
+const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf8'));
+const REAL_INPUT_MATRIX = registry.fixtures
+  .filter((f) => f.enabled)
+  .map((f) => ({
+    slug: f.slug,
+    gameName: f.gameName,
+    metadata: path.join(REAL_INPUT_DIR, f.metadataFile),
+    extract: path.join(REAL_INPUT_DIR, f.rulebookExtractFile),
+    expected: path.join(REAL_INPUT_DIR, f.expectedFile),
+  }));
 
 // ---------------------------------------------------------------------------
 // FFmpeg availability detection (same pattern as storyboard_ffmpeg_real_mp4)

--- a/tests/fixtures/tutorial-real-input/README.md
+++ b/tests/fixtures/tutorial-real-input/README.md
@@ -25,14 +25,41 @@ Each fixture simulates the output of a two-layer ingestion process:
 - No network-dependent image downloads.
 - All data is checked in and deterministic.
 
-## Fixture Matrix
+## Fixture Registry
+
+All real-input fixtures are registered in **`fixtures.json`**. The E2E smoke test
+and registry validation tests load this file to discover enabled fixtures
+automatically.
+
+### Registry format
+
+```json
+{
+  "_schema": "Real-input fixture registry",
+  "_version": 1,
+  "fixtures": [
+    {
+      "slug": "game-slug",
+      "gameName": "Game Name",
+      "profile": "Brief teaching profile description",
+      "enabled": true,
+      "metadataFile": "game-slug.metadata.json",
+      "rulebookExtractFile": "game-slug.rulebook-extract.json",
+      "expectedFile": "game-slug.expected.json",
+      "notes": "Optional notes about the fixture"
+    }
+  ]
+}
+```
+
+### Current fixtures
 
 | Slug | Game | Teaching Profile | Duration Range |
 |------|------|------------------|----------------|
 | `sakura-market` | Sakura Market | Competitive market-timing with dice-driven price fluctuation | 60–180s |
 | `stellar-drift` | Stellar Drift | Cooperative tile-laying route-building through asteroids | 50–130s |
 
-The fixture matrix is designed to exercise different tutorial structures:
+The fixture matrix exercises different tutorial structures:
 - Different player counts (2–5 vs 1–4)
 - Different turn phase names (Move/Trade/Refresh vs Draw/Place/Drift)
 - Different scoring models (competitive coin-counting vs cooperative pass/fail)
@@ -46,6 +73,7 @@ Each fixture consists of layered input files and a contract:
 
 | File | Role |
 |------|------|
+| `fixtures.json` | Registry of all fixtures (discovery source) |
 | `<slug>.metadata.json` | Simulated BGG metadata (game name, player count, playtime, designers) |
 | `<slug>.rulebook-extract.json` | Structured rulebook extraction (objective, components, setup, turns, scoring) |
 | `<slug>.expected.json` | Artifact contract — expected validation assertions for rendered output |
@@ -91,12 +119,42 @@ The contract validator checks:
 | Content | Validates script segments, storyboard scenes, captions cue count | Focuses on artifact existence and media properties |
 | Use case | Deterministic golden baseline comparison | Realistic variable-length content validation |
 
-## Adding a New Fixture
+## How to Add a New Real-Input Fixture
 
-1. Create `<slug>.metadata.json` following the BGG-style schema (see `sakura-market.metadata.json`).
-2. Create `<slug>.rulebook-extract.json` with objective, components, setup, turnStructure, coreMechanic, scoring, edgeCases.
-3. Create `<slug>.expected.json` with gameId, gameName, fixtureSlug, durationRange, requiredArtifacts, media, manifest, minMp4Bytes.
-4. Add the new entry to `REAL_INPUT_MATRIX` in `tests/e2e/tutorial_full_flow_smoke.test.js`.
-5. Add normalizer unit tests in `tests/scripts/normalizeRealInputFixture.test.js`.
-6. Run `node scripts/normalize-real-input-fixture.cjs --metadata <meta> --extract <extract>` to verify normalizer output.
-7. Push and verify CI passes on all OS targets.
+1. **Create fixture files** in this directory:
+   - `<slug>.metadata.json` — follow the BGG-style schema (see `sakura-market.metadata.json`)
+   - `<slug>.rulebook-extract.json` — include objective, components, setup, turnStructure, coreMechanic, scoring, edgeCases
+   - `<slug>.expected.json` — include gameId, gameName, fixtureSlug, durationRange, requiredArtifacts, media, manifest, minMp4Bytes
+
+2. **Register in `fixtures.json`** — add an entry to the `fixtures` array with all required fields. Set `enabled: true`.
+
+3. **Verify identity consistency** — ensure:
+   - `metadata.slug` matches the registry `slug`
+   - `metadata.title` matches the registry `gameName`
+   - `expected.gameId` / `expected.gameName` / `expected.fixtureSlug` match the registry
+
+4. **Run registry validation**:
+   ```bash
+   npx jest tests/scripts/realInputFixtureRegistry.test.js --no-coverage
+   ```
+
+5. **Run normalizer** to verify output:
+   ```bash
+   node scripts/normalize-real-input-fixture.cjs --metadata <meta> --extract <extract>
+   ```
+
+6. **Add normalizer unit tests** in `tests/scripts/normalizeRealInputFixture.test.js`.
+
+7. **Push and verify CI** passes on all OS targets. No test code changes are needed — the E2E smoke automatically discovers enabled fixtures from the registry.
+
+## Registry Validation
+
+The test `tests/scripts/realInputFixtureRegistry.test.js` enforces:
+- `fixtures.json` is valid JSON with a `fixtures` array
+- At least one fixture is enabled
+- No duplicate slugs
+- Each entry has all required fields
+- All referenced files exist on disk
+- Metadata slug/title match registry slug/gameName
+- Expected contract identity matches registry
+- Rulebook extracts have required sections with non-empty content

--- a/tests/fixtures/tutorial-real-input/fixtures.json
+++ b/tests/fixtures/tutorial-real-input/fixtures.json
@@ -1,0 +1,27 @@
+{
+  "_schema": "Real-input fixture registry — lists all product-like tutorial samples",
+  "_version": 1,
+
+  "fixtures": [
+    {
+      "slug": "sakura-market",
+      "gameName": "Sakura Market",
+      "profile": "Competitive market-timing with dice-driven price fluctuation",
+      "enabled": true,
+      "metadataFile": "sakura-market.metadata.json",
+      "rulebookExtractFile": "sakura-market.rulebook-extract.json",
+      "expectedFile": "sakura-market.expected.json",
+      "notes": "First real-input fixture. 2-5 players, 30-45 min, single designer."
+    },
+    {
+      "slug": "stellar-drift",
+      "gameName": "Stellar Drift",
+      "profile": "Cooperative tile-laying route-building through asteroids",
+      "enabled": true,
+      "metadataFile": "stellar-drift.metadata.json",
+      "rulebookExtractFile": "stellar-drift.rulebook-extract.json",
+      "expectedFile": "stellar-drift.expected.json",
+      "notes": "Second fixture. 1-4 players, 20 min fixed, multiple designers, cooperative."
+    }
+  ]
+}

--- a/tests/scripts/realInputFixtureRegistry.test.js
+++ b/tests/scripts/realInputFixtureRegistry.test.js
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the real-input fixture registry.
+ *
+ * Validates that fixtures.json is well-formed and all referenced files exist,
+ * preventing silent breakage when adding or modifying fixtures.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const REGISTRY_DIR = path.resolve(__dirname, '../fixtures/tutorial-real-input');
+const REGISTRY_PATH = path.join(REGISTRY_DIR, 'fixtures.json');
+
+// ---------------------------------------------------------------------------
+// Load registry
+// ---------------------------------------------------------------------------
+let registry;
+
+beforeAll(() => {
+  const raw = fs.readFileSync(REGISTRY_PATH, 'utf8');
+  registry = JSON.parse(raw);
+});
+
+// ---------------------------------------------------------------------------
+// Registry structure tests
+// ---------------------------------------------------------------------------
+describe('fixtures.json registry structure', () => {
+  test('registry file exists and is valid JSON', () => {
+    expect(fs.existsSync(REGISTRY_PATH)).toBe(true);
+    expect(registry).toBeDefined();
+  });
+
+  test('registry has a fixtures array', () => {
+    expect(Array.isArray(registry.fixtures)).toBe(true);
+  });
+
+  test('registry has at least one enabled fixture', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    expect(enabled.length).toBeGreaterThan(0);
+  });
+
+  test('no duplicate slugs', () => {
+    const slugs = registry.fixtures.map((f) => f.slug);
+    const unique = new Set(slugs);
+    expect(unique.size).toBe(slugs.length);
+  });
+
+  test('each fixture has required fields', () => {
+    const REQUIRED = ['slug', 'gameName', 'profile', 'enabled', 'metadataFile', 'rulebookExtractFile', 'expectedFile'];
+    for (const fixture of registry.fixtures) {
+      for (const field of REQUIRED) {
+        expect(fixture).toHaveProperty(field);
+      }
+    }
+  });
+
+  test('each slug is a non-empty string', () => {
+    for (const fixture of registry.fixtures) {
+      expect(typeof fixture.slug).toBe('string');
+      expect(fixture.slug.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('each gameName is a non-empty string', () => {
+    for (const fixture of registry.fixtures) {
+      expect(typeof fixture.gameName).toBe('string');
+      expect(fixture.gameName.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File existence tests
+// ---------------------------------------------------------------------------
+describe('fixtures.json — referenced files exist', () => {
+  test('each enabled fixture has a metadata file', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const filePath = path.join(REGISTRY_DIR, fixture.metadataFile);
+      expect(fs.existsSync(filePath)).toBe(true);
+    }
+  });
+
+  test('each enabled fixture has a rulebook-extract file', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const filePath = path.join(REGISTRY_DIR, fixture.rulebookExtractFile);
+      expect(fs.existsSync(filePath)).toBe(true);
+    }
+  });
+
+  test('each enabled fixture has an expected-contract file', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const filePath = path.join(REGISTRY_DIR, fixture.expectedFile);
+      expect(fs.existsSync(filePath)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Identity consistency tests
+// ---------------------------------------------------------------------------
+describe('fixtures.json — identity consistency', () => {
+  test('metadata slug matches registry slug', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const metadata = JSON.parse(fs.readFileSync(path.join(REGISTRY_DIR, fixture.metadataFile), 'utf8'));
+      expect(metadata.slug).toBe(fixture.slug);
+    }
+  });
+
+  test('metadata title matches registry gameName', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const metadata = JSON.parse(fs.readFileSync(path.join(REGISTRY_DIR, fixture.metadataFile), 'utf8'));
+      expect(metadata.title).toBe(fixture.gameName);
+    }
+  });
+
+  test('expected contract gameId matches registry slug', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const expected = JSON.parse(fs.readFileSync(path.join(REGISTRY_DIR, fixture.expectedFile), 'utf8'));
+      expect(expected.gameId).toBe(fixture.slug);
+    }
+  });
+
+  test('expected contract gameName matches registry gameName', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const expected = JSON.parse(fs.readFileSync(path.join(REGISTRY_DIR, fixture.expectedFile), 'utf8'));
+      expect(expected.gameName).toBe(fixture.gameName);
+    }
+  });
+
+  test('expected contract fixtureSlug matches registry slug', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const expected = JSON.parse(fs.readFileSync(path.join(REGISTRY_DIR, fixture.expectedFile), 'utf8'));
+      expect(expected.fixtureSlug).toBe(fixture.slug);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rulebook extract completeness tests
+// ---------------------------------------------------------------------------
+describe('fixtures.json — rulebook extract completeness', () => {
+  test('each enabled fixture rulebook-extract has required sections', () => {
+    const REQUIRED_SECTIONS = ['objective', 'components', 'setup', 'turnStructure', 'coreMechanic', 'scoring'];
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const extract = JSON.parse(fs.readFileSync(path.join(REGISTRY_DIR, fixture.rulebookExtractFile), 'utf8'));
+      for (const section of REQUIRED_SECTIONS) {
+        expect(extract).toHaveProperty(section);
+      }
+    }
+  });
+
+  test('each enabled fixture rulebook-extract has non-empty components', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const extract = JSON.parse(fs.readFileSync(path.join(REGISTRY_DIR, fixture.rulebookExtractFile), 'utf8'));
+      expect(Array.isArray(extract.components)).toBe(true);
+      expect(extract.components.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('each enabled fixture rulebook-extract has non-empty setup', () => {
+    const enabled = registry.fixtures.filter((f) => f.enabled);
+    for (const fixture of enabled) {
+      const extract = JSON.parse(fs.readFileSync(path.join(REGISTRY_DIR, fixture.rulebookExtractFile), 'utf8'));
+      expect(Array.isArray(extract.setup)).toBe(true);
+      expect(extract.setup.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary Replaces the hardcoded real-input fixture matrix with a registry-driven auto-discovery system. Adding a new fixture now requires only adding fixture files and a registry entry — no test code changes needed. ## Changes - **	ests/fixtures/tutorial-real-input/fixtures.json** — New registry listing all real-input fixtures with slug, gameName, profile, enabled status, and file references - **	ests/scripts/realInputFixtureRegistry.test.js** — 18 registry validation tests covering structure, file existence, identity consistency, and rulebook extract completeness - **	ests/e2e/tutorial_full_flow_smoke.test.js** — Loads \REAL_INPUT_MATRIX\ from registry instead of hardcoded array - **	ests/fixtures/tutorial-real-input/README.md** — Registry format docs and updated step-by-step fixture addition guide ## Registry validation catches - Missing files for enabled fixtures - Duplicate slugs - Identity mismatches (metadata.slug vs registry, expected.gameId vs registry) - Rulebook extracts missing required sections - Empty enabled fixture set ## What stays unchanged - Deterministic gem-collectors smoke (first describe block) - Real-input fixture behavior (sakura-market + stellar-drift both run) - Normalizer logic - Contract validator logic - Golden baselines and golden checks workflow - Renderer logic ## Testing - 18 registry validation tests pass - 30 normalizer tests pass - 18 validator tests pass - Full local suite: 50 suites, 543 tests (541 passed, 1 skipped, 1 pre-existing EPERM flake on Windows) - E2e smoke exercises both fixtures via CI (FFmpeg-dependent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a registry-based workflow for real-input tutorial fixtures, so enabled fixtures are discovered automatically.
  * Introduced a new fixture registry validation test to check required fields, file presence, and content consistency.

* **Documentation**
  * Updated fixture setup docs with a clear registry format, validation steps, and instructions for adding new fixtures.

* **Bug Fixes**
  * Removed hardcoded fixture entries from the smoke test, reducing manual maintenance and keeping test coverage aligned with the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->