### PR TITLE
feat: real-input smoke coverage report v1

### DIFF
--- a/tests/e2e/tutorial_full_flow_smoke.test.js
+++ b/tests/e2e/tutorial_full_flow_smoke.test.js
@@ -20,6 +20,8 @@ const VALIDATE_SCRIPT = path.resolve(__dirname, '../../scripts/validate-tutorial
 const VALIDATE_REAL_INPUT_SCRIPT = path.resolve(__dirname, '../../scripts/validate-real-input-preview-artifact.mjs');
 const FIXTURE = path.resolve(__dirname, '../fixtures/tutorial-vertical-slice/gem-collectors.json');
 const NORMALIZER_SCRIPT = path.resolve(__dirname, '../../scripts/normalize-real-input-fixture.cjs');
+const { validateRealInputArtifact } = require('../../scripts/validate-real-input-preview-artifact.cjs');
+const { createReport, buildFixtureEntry, writeReport } = require('../helpers/realInputSmokeCoverageReport.cjs');
 
 // ---------------------------------------------------------------------------
 // Real-input fixture matrix (loaded from registry)
@@ -33,10 +35,21 @@ const REAL_INPUT_MATRIX = registry.fixtures
   .map((f) => ({
     slug: f.slug,
     gameName: f.gameName,
+    profile: f.profile,
     metadata: path.join(REAL_INPUT_DIR, f.metadataFile),
     extract: path.join(REAL_INPUT_DIR, f.rulebookExtractFile),
     expected: path.join(REAL_INPUT_DIR, f.expectedFile),
+    metadataFile: f.metadataFile,
+    rulebookExtractFile: f.rulebookExtractFile,
+    expectedFile: f.expectedFile,
   }));
+
+// ---------------------------------------------------------------------------
+// Coverage report accumulator
+// ---------------------------------------------------------------------------
+const coverageReportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mobius-smoke-coverage-'));
+const coverageReport = createReport({ registryPath: REGISTRY_PATH, enabledCount: REAL_INPUT_MATRIX.length });
+const COVERAGE_REPORT_PATH = path.join(coverageReportDir, 'real-input-smoke-coverage.json');
 
 // ---------------------------------------------------------------------------
 // FFmpeg availability detection (same pattern as storyboard_ffmpeg_real_mp4)
@@ -251,6 +264,7 @@ describe.each(REAL_INPUT_MATRIX)('Real-Input Smoke ($slug → MP4)', (fixtureEnt
   let tmpDir;
   let outDir;
   let mp4Path;
+  let normalizedFixturePath;
 
   beforeAll(() => {
     tmpDir = createTempDir();
@@ -258,7 +272,7 @@ describe.each(REAL_INPUT_MATRIX)('Real-Input Smoke ($slug → MP4)', (fixtureEnt
     mp4Path = path.join(outDir, 'preview.mp4');
 
     // Step 0: Normalize metadata + rulebook-extract into canonical fixture
-    const normalizedFixturePath = path.join(tmpDir, `${fixtureEntry.slug}-normalized.json`);
+    normalizedFixturePath = path.join(tmpDir, `${fixtureEntry.slug}-normalized.json`);
     execFileSync('node', [
       NORMALIZER_SCRIPT,
       '--metadata', fixtureEntry.metadata,
@@ -307,6 +321,42 @@ describe.each(REAL_INPUT_MATRIX)('Real-Input Smoke ($slug → MP4)', (fixtureEnt
   }, 300000);
 
   afterAll(() => {
+    // Build coverage report entry for this fixture
+    try {
+      const ffprobeData = fs.existsSync(path.join(outDir, 'ffprobe.json'))
+        ? JSON.parse(fs.readFileSync(path.join(outDir, 'ffprobe.json'), 'utf8'))
+        : null;
+      const manifestData = fs.existsSync(path.join(outDir, 'manifest.json'))
+        ? JSON.parse(fs.readFileSync(path.join(outDir, 'manifest.json'), 'utf8'))
+        : null;
+      const expectedContract = JSON.parse(fs.readFileSync(fixtureEntry.expected, 'utf8'));
+      const contractResult = validateRealInputArtifact(outDir, expectedContract);
+
+      const entry = buildFixtureEntry({
+        slug: fixtureEntry.slug,
+        gameName: fixtureEntry.gameName,
+        profile: fixtureEntry.profile,
+        metadataFile: fixtureEntry.metadataFile,
+        rulebookExtractFile: fixtureEntry.rulebookExtractFile,
+        expectedFile: fixtureEntry.expectedFile,
+        normalizedFixturePath,
+        artifactDir: outDir,
+        ffprobeData,
+        manifestData,
+        requiredArtifacts: expectedContract.requiredArtifacts || [],
+        contractValidation: contractResult,
+      });
+      coverageReport.fixtures.push(entry);
+    } catch (err) {
+      // If report entry build fails, still record a minimal entry
+      coverageReport.fixtures.push({
+        slug: fixtureEntry.slug,
+        gameName: fixtureEntry.gameName,
+        error: err.message,
+      });
+    }
+
+    // Cleanup temp dir
     try {
       if (tmpDir && fs.existsSync(tmpDir)) {
         fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -368,3 +418,61 @@ describe.each(REAL_INPUT_MATRIX)('Real-Input Smoke ($slug → MP4)', (fixtureEnt
   });
 });
 
+
+
+
+// ---------------------------------------------------------------------------
+// Coverage report finalization
+// ---------------------------------------------------------------------------
+describe('Real-Input Smoke Coverage Report', () => {
+  afterAll(() => {
+    // Write coverage report regardless of CAN_RUN (will contain 0 entries if skipped)
+    writeReport(COVERAGE_REPORT_PATH, coverageReport);
+    console.log(`[coverage] Real-input smoke coverage report written to: ${COVERAGE_REPORT_PATH}`);
+
+    // Cleanup report dir after tests read it
+    // Note: not cleaning up here so CI can inspect if needed
+  });
+
+  test('coverage report is written to disk', () => {
+    writeReport(COVERAGE_REPORT_PATH, coverageReport);
+    expect(fs.existsSync(COVERAGE_REPORT_PATH)).toBe(true);
+  });
+
+  test('coverage report has correct schema version', () => {
+    writeReport(COVERAGE_REPORT_PATH, coverageReport);
+    const loaded = JSON.parse(fs.readFileSync(COVERAGE_REPORT_PATH, 'utf8'));
+    expect(loaded._schema).toBe('real-input-smoke-coverage/v1');
+  });
+
+  test('coverage report references the registry path', () => {
+    writeReport(COVERAGE_REPORT_PATH, coverageReport);
+    const loaded = JSON.parse(fs.readFileSync(COVERAGE_REPORT_PATH, 'utf8'));
+    expect(loaded.registryPath).toBe(REGISTRY_PATH);
+  });
+
+  test('coverage report enabled count matches registry', () => {
+    writeReport(COVERAGE_REPORT_PATH, coverageReport);
+    const loaded = JSON.parse(fs.readFileSync(COVERAGE_REPORT_PATH, 'utf8'));
+    expect(loaded.enabledFixtureCount).toBe(REAL_INPUT_MATRIX.length);
+  });
+
+  if (CAN_RUN) {
+    test('coverage report contains exactly the enabled fixture slugs', () => {
+      writeReport(COVERAGE_REPORT_PATH, coverageReport);
+      const loaded = JSON.parse(fs.readFileSync(COVERAGE_REPORT_PATH, 'utf8'));
+      const reportSlugs = loaded.fixtures.map((f) => f.slug).sort();
+      const expectedSlugs = REAL_INPUT_MATRIX.map((f) => f.slug).sort();
+      expect(reportSlugs).toEqual(expectedSlugs);
+    });
+
+    test('coverage report contains no disabled or unregistered fixtures', () => {
+      writeReport(COVERAGE_REPORT_PATH, coverageReport);
+      const loaded = JSON.parse(fs.readFileSync(COVERAGE_REPORT_PATH, 'utf8'));
+      const registeredSlugs = new Set(REAL_INPUT_MATRIX.map((f) => f.slug));
+      for (const entry of loaded.fixtures) {
+        expect(registeredSlugs.has(entry.slug)).toBe(true);
+      }
+    });
+  }
+});

--- a/tests/fixtures/tutorial-real-input/README.md
+++ b/tests/fixtures/tutorial-real-input/README.md
@@ -158,3 +158,83 @@ The test `tests/scripts/realInputFixtureRegistry.test.js` enforces:
 - Metadata slug/title match registry slug/gameName
 - Expected contract identity matches registry
 - Rulebook extracts have required sections with non-empty content
+
+
+## Smoke Coverage Report
+
+When the E2E smoke test runs (`tests/e2e/tutorial_full_flow_smoke.test.js`), it
+generates a structured coverage report at a temporary path:
+
+```
+<temp-dir>/real-input-smoke-coverage.json
+```
+
+### Report schema (`real-input-smoke-coverage/v1`)
+
+```json
+{
+  "_schema": "real-input-smoke-coverage/v1",
+  "generatedAt": "2025-01-15T12:00:00.000Z",
+  "registryPath": "/abs/path/to/fixtures.json",
+  "enabledFixtureCount": 2,
+  "fixtures": [
+    {
+      "slug": "sakura-market",
+      "gameName": "Sakura Market",
+      "profile": "Competitive market-timing...",
+      "metadataFile": "sakura-market.metadata.json",
+      "rulebookExtractFile": "sakura-market.rulebook-extract.json",
+      "expectedFile": "sakura-market.expected.json",
+      "normalizedFixturePath": "/tmp/.../sakura-market-normalized.json",
+      "artifactDir": "/tmp/.../tutorial-preview-sakura-market",
+      "artifactPresence": {
+        "preview.mp4": true,
+        "script.json": true,
+        "storyboard.json": true,
+        "captions.srt": true,
+        "render-config.json": true,
+        "manifest.json": true,
+        "ffprobe.json": true
+      },
+      "manifestIdentity": {
+        "gameId": "sakura-market",
+        "gameName": "Sakura Market",
+        "fixtureSlug": "sakura-market"
+      },
+      "media": {
+        "duration": 118.3,
+        "videoCodec": "h264",
+        "videoWidth": 1920,
+        "videoHeight": 1080,
+        "audioPresent": true
+      },
+      "contractValidation": {
+        "passed": true,
+        "errorCount": 0,
+        "errors": []
+      }
+    }
+  ]
+}
+```
+
+### What the report proves
+
+- Which fixtures were enabled and ran
+- Normalized input provenance (which metadata + extract files produced it)
+- All required artifacts were generated and are non-empty
+- Manifest identity matches the fixture registry
+- MP4 media properties: duration, codec, resolution, audio presence
+- Contract validation passed for each fixture
+
+### Where the report lives
+
+The report is written to a temporary directory during test execution and is
+**not committed to Git**. It is available for CI inspection via test output logs
+(the path is printed to stdout). Future CI enhancements may upload it as an
+artifact for dashboard consumption.
+
+### Helper module
+
+The report generation logic is in `tests/helpers/realInputSmokeCoverageReport.cjs`
+with unit tests at `tests/scripts/realInputSmokeCoverageReport.test.js`.

--- a/tests/helpers/realInputSmokeCoverageReport.cjs
+++ b/tests/helpers/realInputSmokeCoverageReport.cjs
@@ -1,0 +1,143 @@
+/**
+ * realInputSmokeCoverageReport.cjs — Helper for generating structured
+ * real-input smoke coverage reports.
+ *
+ * Dependency-free, cross-platform, deterministic.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const SCHEMA_VERSION = 'real-input-smoke-coverage/v1';
+
+/**
+ * Create a new empty coverage report.
+ * @param {object} opts
+ * @param {string} opts.registryPath - Absolute path to fixtures.json
+ * @param {number} opts.enabledCount - Number of enabled fixtures
+ * @returns {object} Report skeleton
+ */
+function createReport({ registryPath, enabledCount }) {
+  return {
+    _schema: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    registryPath,
+    enabledFixtureCount: enabledCount,
+    fixtures: [],
+  };
+}
+
+/**
+ * Build a fixture entry for the coverage report.
+ * @param {object} opts
+ * @param {string} opts.slug
+ * @param {string} opts.gameName
+ * @param {string} opts.profile
+ * @param {string} opts.metadataFile
+ * @param {string} opts.rulebookExtractFile
+ * @param {string} opts.expectedFile
+ * @param {string} opts.normalizedFixturePath - Path to the normalized canonical fixture
+ * @param {string} opts.artifactDir - Output directory for generated artifacts
+ * @param {object} opts.ffprobeData - Parsed ffprobe.json content (or null)
+ * @param {object} opts.manifestData - Parsed manifest.json content (or null)
+ * @param {string[]} opts.requiredArtifacts - List of expected artifact filenames
+ * @param {object} opts.contractValidation - { passed: boolean, errors: string[] }
+ * @returns {object} Fixture report entry
+ */
+function buildFixtureEntry({
+  slug,
+  gameName,
+  profile,
+  metadataFile,
+  rulebookExtractFile,
+  expectedFile,
+  normalizedFixturePath,
+  artifactDir,
+  ffprobeData,
+  manifestData,
+  requiredArtifacts,
+  contractValidation,
+}) {
+  // Artifact presence summary
+  const artifactPresence = {};
+  for (const file of (requiredArtifacts || [])) {
+    const filePath = path.join(artifactDir, file);
+    artifactPresence[file] = fs.existsSync(filePath) && fs.statSync(filePath).size > 0;
+  }
+
+  // Extract media metadata from ffprobe
+  let duration = null;
+  let videoCodec = null;
+  let videoWidth = null;
+  let videoHeight = null;
+  let audioPresent = false;
+
+  if (ffprobeData) {
+    const streams = ffprobeData.streams || [];
+    const videoStream = streams.find((s) => s.codec_type === 'video');
+    const audioStream = streams.find((s) => s.codec_type === 'audio');
+
+    if (ffprobeData.format && ffprobeData.format.duration) {
+      duration = parseFloat(ffprobeData.format.duration);
+    }
+    if (videoStream) {
+      videoCodec = videoStream.codec_name || null;
+      videoWidth = videoStream.width != null ? Number(videoStream.width) : null;
+      videoHeight = videoStream.height != null ? Number(videoStream.height) : null;
+    }
+    audioPresent = !!audioStream;
+  }
+
+  // Extract manifest identity
+  let manifestIdentity = null;
+  if (manifestData) {
+    manifestIdentity = {
+      gameId: manifestData.game?.id || null,
+      gameName: manifestData.game?.name || null,
+      fixtureSlug: manifestData.fixtureSlug || null,
+    };
+  }
+
+  return {
+    slug,
+    gameName,
+    profile,
+    metadataFile,
+    rulebookExtractFile,
+    expectedFile,
+    normalizedFixturePath,
+    artifactDir,
+    artifactPresence,
+    manifestIdentity,
+    media: {
+      duration,
+      videoCodec,
+      videoWidth,
+      videoHeight,
+      audioPresent,
+    },
+    contractValidation: {
+      passed: contractValidation ? contractValidation.passed : false,
+      errorCount: contractValidation ? contractValidation.errors.length : 0,
+      errors: contractValidation ? contractValidation.errors : [],
+    },
+  };
+}
+
+/**
+ * Write the coverage report to disk.
+ * @param {string} outputPath - Absolute path to write report JSON
+ * @param {object} report - Report object from createReport + fixture entries
+ */
+function writeReport(outputPath, report) {
+  fs.writeFileSync(outputPath, JSON.stringify(report, null, 2), 'utf8');
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  createReport,
+  buildFixtureEntry,
+  writeReport,
+};

--- a/tests/scripts/realInputSmokeCoverageReport.test.js
+++ b/tests/scripts/realInputSmokeCoverageReport.test.js
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for realInputSmokeCoverageReport helper.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const {
+  SCHEMA_VERSION,
+  createReport,
+  buildFixtureEntry,
+  writeReport,
+} = require('../helpers/realInputSmokeCoverageReport.cjs');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mobius-coverage-report-test-'));
+}
+
+function buildValidArtifactDir(dir) {
+  fs.writeFileSync(path.join(dir, 'preview.mp4'), Buffer.alloc(20000, 0x42));
+  fs.writeFileSync(path.join(dir, 'script.json'), '{"segments":[]}');
+  fs.writeFileSync(path.join(dir, 'storyboard.json'), '{"scenes":[]}');
+  fs.writeFileSync(path.join(dir, 'captions.srt'), '1\n00:00:00,000 --> 00:00:05,000\nTest\n');
+  fs.writeFileSync(path.join(dir, 'render-config.json'), '{"projectId":"test"}');
+  fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify({
+    game: { id: 'test-game', name: 'Test Game' },
+    fixtureSlug: 'test-game',
+  }));
+  fs.writeFileSync(path.join(dir, 'ffprobe.json'), JSON.stringify({
+    streams: [
+      { codec_type: 'video', codec_name: 'h264', width: 1920, height: 1080 },
+      { codec_type: 'audio', codec_name: 'aac' },
+    ],
+    format: { duration: '95.5' },
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests: createReport
+// ---------------------------------------------------------------------------
+describe('createReport', () => {
+  test('returns report with correct schema version', () => {
+    const report = createReport({ registryPath: '/path/to/fixtures.json', enabledCount: 2 });
+    expect(report._schema).toBe(SCHEMA_VERSION);
+  });
+
+  test('returns report with generatedAt timestamp', () => {
+    const before = new Date().toISOString();
+    const report = createReport({ registryPath: '/path', enabledCount: 1 });
+    const after = new Date().toISOString();
+    expect(report.generatedAt >= before).toBe(true);
+    expect(report.generatedAt <= after).toBe(true);
+  });
+
+  test('returns report with registryPath and enabledFixtureCount', () => {
+    const report = createReport({ registryPath: '/my/registry.json', enabledCount: 3 });
+    expect(report.registryPath).toBe('/my/registry.json');
+    expect(report.enabledFixtureCount).toBe(3);
+  });
+
+  test('returns report with empty fixtures array', () => {
+    const report = createReport({ registryPath: '/path', enabledCount: 0 });
+    expect(report.fixtures).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: buildFixtureEntry
+// ---------------------------------------------------------------------------
+describe('buildFixtureEntry', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+    buildValidArtifactDir(tmpDir);
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  });
+
+  test('populates slug, gameName, and profile', () => {
+    const entry = buildFixtureEntry({
+      slug: 'test-game',
+      gameName: 'Test Game',
+      profile: 'Test profile',
+      metadataFile: 'test.metadata.json',
+      rulebookExtractFile: 'test.rulebook-extract.json',
+      expectedFile: 'test.expected.json',
+      normalizedFixturePath: '/tmp/test.json',
+      artifactDir: tmpDir,
+      ffprobeData: JSON.parse(fs.readFileSync(path.join(tmpDir, 'ffprobe.json'), 'utf8')),
+      manifestData: JSON.parse(fs.readFileSync(path.join(tmpDir, 'manifest.json'), 'utf8')),
+      requiredArtifacts: ['preview.mp4', 'script.json'],
+      contractValidation: { passed: true, errors: [] },
+    });
+    expect(entry.slug).toBe('test-game');
+    expect(entry.gameName).toBe('Test Game');
+    expect(entry.profile).toBe('Test profile');
+  });
+
+  test('reports artifact presence correctly', () => {
+    const entry = buildFixtureEntry({
+      slug: 'x', gameName: 'X', profile: 'p',
+      metadataFile: 'a', rulebookExtractFile: 'b', expectedFile: 'c',
+      normalizedFixturePath: '/tmp/x.json',
+      artifactDir: tmpDir,
+      ffprobeData: null, manifestData: null,
+      requiredArtifacts: ['preview.mp4', 'script.json', 'nonexistent.txt'],
+      contractValidation: { passed: false, errors: ['missing'] },
+    });
+    expect(entry.artifactPresence['preview.mp4']).toBe(true);
+    expect(entry.artifactPresence['script.json']).toBe(true);
+    expect(entry.artifactPresence['nonexistent.txt']).toBe(false);
+  });
+
+  test('extracts media metadata from ffprobeData', () => {
+    const ffprobe = {
+      streams: [
+        { codec_type: 'video', codec_name: 'h264', width: 1920, height: 1080 },
+        { codec_type: 'audio', codec_name: 'aac' },
+      ],
+      format: { duration: '118.3' },
+    };
+    const entry = buildFixtureEntry({
+      slug: 'x', gameName: 'X', profile: 'p',
+      metadataFile: 'a', rulebookExtractFile: 'b', expectedFile: 'c',
+      normalizedFixturePath: '/tmp/x.json',
+      artifactDir: tmpDir,
+      ffprobeData: ffprobe, manifestData: null,
+      requiredArtifacts: [],
+      contractValidation: { passed: true, errors: [] },
+    });
+    expect(entry.media.duration).toBeCloseTo(118.3);
+    expect(entry.media.videoCodec).toBe('h264');
+    expect(entry.media.videoWidth).toBe(1920);
+    expect(entry.media.videoHeight).toBe(1080);
+    expect(entry.media.audioPresent).toBe(true);
+  });
+
+  test('handles missing audio stream', () => {
+    const ffprobe = {
+      streams: [{ codec_type: 'video', codec_name: 'h264', width: 1280, height: 720 }],
+      format: { duration: '60.0' },
+    };
+    const entry = buildFixtureEntry({
+      slug: 'x', gameName: 'X', profile: 'p',
+      metadataFile: 'a', rulebookExtractFile: 'b', expectedFile: 'c',
+      normalizedFixturePath: '/tmp/x.json',
+      artifactDir: tmpDir,
+      ffprobeData: ffprobe, manifestData: null,
+      requiredArtifacts: [],
+      contractValidation: { passed: true, errors: [] },
+    });
+    expect(entry.media.audioPresent).toBe(false);
+  });
+
+  test('handles null ffprobeData gracefully', () => {
+    const entry = buildFixtureEntry({
+      slug: 'x', gameName: 'X', profile: 'p',
+      metadataFile: 'a', rulebookExtractFile: 'b', expectedFile: 'c',
+      normalizedFixturePath: '/tmp/x.json',
+      artifactDir: tmpDir,
+      ffprobeData: null, manifestData: null,
+      requiredArtifacts: [],
+      contractValidation: { passed: true, errors: [] },
+    });
+    expect(entry.media.duration).toBeNull();
+    expect(entry.media.videoCodec).toBeNull();
+    expect(entry.media.audioPresent).toBe(false);
+  });
+
+  test('extracts manifest identity', () => {
+    const manifest = { game: { id: 'my-game', name: 'My Game' }, fixtureSlug: 'my-game' };
+    const entry = buildFixtureEntry({
+      slug: 'x', gameName: 'X', profile: 'p',
+      metadataFile: 'a', rulebookExtractFile: 'b', expectedFile: 'c',
+      normalizedFixturePath: '/tmp/x.json',
+      artifactDir: tmpDir,
+      ffprobeData: null, manifestData: manifest,
+      requiredArtifacts: [],
+      contractValidation: { passed: true, errors: [] },
+    });
+    expect(entry.manifestIdentity.gameId).toBe('my-game');
+    expect(entry.manifestIdentity.gameName).toBe('My Game');
+    expect(entry.manifestIdentity.fixtureSlug).toBe('my-game');
+  });
+
+  test('handles null manifestData gracefully', () => {
+    const entry = buildFixtureEntry({
+      slug: 'x', gameName: 'X', profile: 'p',
+      metadataFile: 'a', rulebookExtractFile: 'b', expectedFile: 'c',
+      normalizedFixturePath: '/tmp/x.json',
+      artifactDir: tmpDir,
+      ffprobeData: null, manifestData: null,
+      requiredArtifacts: [],
+      contractValidation: { passed: true, errors: [] },
+    });
+    expect(entry.manifestIdentity).toBeNull();
+  });
+
+  test('includes contract validation result', () => {
+    const entry = buildFixtureEntry({
+      slug: 'x', gameName: 'X', profile: 'p',
+      metadataFile: 'a', rulebookExtractFile: 'b', expectedFile: 'c',
+      normalizedFixturePath: '/tmp/x.json',
+      artifactDir: tmpDir,
+      ffprobeData: null, manifestData: null,
+      requiredArtifacts: [],
+      contractValidation: { passed: false, errors: ['err1', 'err2'] },
+    });
+    expect(entry.contractValidation.passed).toBe(false);
+    expect(entry.contractValidation.errorCount).toBe(2);
+    expect(entry.contractValidation.errors).toEqual(['err1', 'err2']);
+  });
+
+  test('handles null contractValidation gracefully', () => {
+    const entry = buildFixtureEntry({
+      slug: 'x', gameName: 'X', profile: 'p',
+      metadataFile: 'a', rulebookExtractFile: 'b', expectedFile: 'c',
+      normalizedFixturePath: '/tmp/x.json',
+      artifactDir: tmpDir,
+      ffprobeData: null, manifestData: null,
+      requiredArtifacts: [],
+      contractValidation: null,
+    });
+    expect(entry.contractValidation.passed).toBe(false);
+    expect(entry.contractValidation.errorCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: writeReport
+// ---------------------------------------------------------------------------
+describe('writeReport', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  });
+
+  test('writes valid JSON to disk', () => {
+    const report = createReport({ registryPath: '/path', enabledCount: 1 });
+    report.fixtures.push({ slug: 'test' });
+    const outputPath = path.join(tmpDir, 'coverage.json');
+    writeReport(outputPath, report);
+
+    expect(fs.existsSync(outputPath)).toBe(true);
+    const loaded = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    expect(loaded._schema).toBe(SCHEMA_VERSION);
+    expect(loaded.fixtures).toHaveLength(1);
+    expect(loaded.fixtures[0].slug).toBe('test');
+  });
+
+  test('report is human-readable (indented)', () => {
+    const report = createReport({ registryPath: '/path', enabledCount: 0 });
+    const outputPath = path.join(tmpDir, 'report.json');
+    writeReport(outputPath, report);
+
+    const raw = fs.readFileSync(outputPath, 'utf8');
+    expect(raw).toContain('\n');
+    expect(raw).toContain('  ');
+  });
+});


### PR DESCRIPTION
## Summary Adds structured coverage reporting to the real-input smoke test. After each registry-driven fixture runs through the full pipeline, the smoke generates a JSON report capturing exactly which fixtures ran, what they produced, and whether contract validation passed. ## Changes - **\	ests/helpers/realInputSmokeCoverageReport.cjs\** — Helper with \createReport\, \uildFixtureEntry\, \writeReport\ functions - **\	ests/scripts/realInputSmokeCoverageReport.test.js\** — 15 unit tests for report helpers - **\	ests/e2e/tutorial_full_flow_smoke.test.js\** — Emits \eal-input-smoke-coverage.json\ with per-fixture entries after each run; adds verification tests for report structure - **\	ests/fixtures/tutorial-real-input/README.md\** — Coverage report schema documentation ## Report captures per fixture - Fixture identity (slug, gameName, profile) - Input provenance (metadata/extract/expected file references) - Normalized fixture path - Artifact presence map (all 7 required artifacts) - Manifest identity (gameId, gameName, fixtureSlug) - Media metadata (duration, video codec, resolution, audio presence) - Contract validation result (passed, errorCount, errors) ## What stays unchanged - Deterministic gem-collectors smoke - Real-input fixture behavior (sakura-market + stellar-drift) - Registry, normalizer, and contract validator logic - Golden baselines and workflow triggers - Renderer logic ## Testing - 15 coverage report helper tests pass - Full local suite: 51 suites, 558 tests (557 passed, 1 skipped) - E2e smoke exercises both fixtures and generates coverage report via CI