### PR TITLE
feat: publish real-input smoke coverage report as CI artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,15 @@ jobs:
             out/preview_with_audio.mp4
           retention-days: 7
 
+      - name: Upload real-input smoke coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-input-smoke-coverage-${{ matrix.os }}
+          path: artifacts/real-input-smoke-coverage.json
+          if-no-files-found: ignore
+          retention-days: 14
+
   phase-e-governance:
     name: Phase E Governance (E1 Ingestion + E2 Storyboard)
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ Thumbs.db
 !/output/.gitkeep
 !/ffmpeg-bin/README.md
 !/exports/.gitkeep
+
+# Generated CI artifacts (not committed)
+artifacts/real-input-smoke-coverage.json

--- a/tests/e2e/tutorial_full_flow_smoke.test.js
+++ b/tests/e2e/tutorial_full_flow_smoke.test.js
@@ -50,6 +50,9 @@ const REAL_INPUT_MATRIX = registry.fixtures
 const coverageReportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mobius-smoke-coverage-'));
 const coverageReport = createReport({ registryPath: REGISTRY_PATH, enabledCount: REAL_INPUT_MATRIX.length });
 const COVERAGE_REPORT_PATH = path.join(coverageReportDir, 'real-input-smoke-coverage.json');
+// Deterministic CI artifact path (workspace-relative, uploaded by CI workflow)
+const CI_ARTIFACT_DIR = path.resolve(__dirname, '../../artifacts');
+const CI_COVERAGE_REPORT_PATH = path.join(CI_ARTIFACT_DIR, 'real-input-smoke-coverage.json');
 
 // ---------------------------------------------------------------------------
 // FFmpeg availability detection (same pattern as storyboard_ffmpeg_real_mp4)
@@ -430,8 +433,16 @@ describe('Real-Input Smoke Coverage Report', () => {
     writeReport(COVERAGE_REPORT_PATH, coverageReport);
     console.log(`[coverage] Real-input smoke coverage report written to: ${COVERAGE_REPORT_PATH}`);
 
-    // Cleanup report dir after tests read it
-    // Note: not cleaning up here so CI can inspect if needed
+    // Also write to deterministic CI artifact path for upload
+    try {
+      if (!fs.existsSync(CI_ARTIFACT_DIR)) {
+        fs.mkdirSync(CI_ARTIFACT_DIR, { recursive: true });
+      }
+      writeReport(CI_COVERAGE_REPORT_PATH, coverageReport);
+      console.log(`[coverage] CI artifact copy written to: ${CI_COVERAGE_REPORT_PATH}`);
+    } catch (err) {
+      console.warn(`[coverage] Could not write CI artifact copy: ${err.message}`);
+    }
   });
 
   test('coverage report is written to disk', () => {

--- a/tests/fixtures/tutorial-real-input/README.md
+++ b/tests/fixtures/tutorial-real-input/README.md
@@ -229,10 +229,33 @@ generates a structured coverage report at a temporary path:
 
 ### Where the report lives
 
-The report is written to a temporary directory during test execution and is
-**not committed to Git**. It is available for CI inspection via test output logs
-(the path is printed to stdout). Future CI enhancements may upload it as an
-artifact for dashboard consumption.
+The report is written to two locations during test execution:
+
+1. **Temporary directory** — primary copy at `<temp-dir>/real-input-smoke-coverage.json`
+   (path printed to stdout during test run).
+2. **CI artifact path** — `artifacts/real-input-smoke-coverage.json` in the workspace
+   root. This path is uploaded as a downloadable GitHub Actions artifact.
+
+The report is **not committed to Git** (the CI artifact path is in `.gitignore`).
+
+### CI artifact
+
+After each `build-and-qa` job completes, the report is uploaded as:
+
+```
+real-input-smoke-coverage-<os>
+```
+
+For example:
+- `real-input-smoke-coverage-ubuntu-latest`
+- `real-input-smoke-coverage-windows-latest`
+- `real-input-smoke-coverage-macos-latest`
+
+Artifacts are retained for 14 days. Download from the GitHub Actions run page
+under the Artifacts section.
+
+The upload uses `if-no-files-found: ignore` so it does not fail the job if the
+smoke was skipped (e.g., on a machine without FFmpeg during local development).
 
 ### Helper module
 


### PR DESCRIPTION
## Summary

Makes the real-input smoke coverage report available as a downloadable CI artifact from each `build-and-qa` job. The report proves which fixtures ran, what they produced, and whether contract validation passed.

## Changes

- **`tests/e2e/tutorial_full_flow_smoke.test.js`** — Writes coverage report to deterministic `artifacts/real-input-smoke-coverage.json` path (in addition to temp dir)
- **`.github/workflows/ci.yml`** — Adds `upload-artifact` step after existing QA upload: artifact name `real-input-smoke-coverage-${{ matrix.os }}`, 14-day retention, `if-no-files-found: ignore`
- **`.gitignore`** — Adds `artifacts/real-input-smoke-coverage.json` to prevent accidental commit
- **`tests/fixtures/tutorial-real-input/README.md`** — Documents CI artifact naming, location, and retention

## Artifact details

| OS | Artifact name |
|----|---------------|
| ubuntu-latest | `real-input-smoke-coverage-ubuntu-latest` |
| windows-latest | `real-input-smoke-coverage-windows-latest` |
| macos-latest | `real-input-smoke-coverage-macos-latest` |

Retention: 14 days. Download from GitHub Actions run page.

## What stays unchanged

- Deterministic gem-collectors smoke
- Real-input fixture behavior (sakura-market + stellar-drift)
- Registry, normalizer, and contract validator logic
- Coverage report schema and helper tests
- Golden baselines and workflow triggers
- Renderer logic

## Testing

- Full local suite: 51 suites, 558 tests (557 passed, 1 skipped)
- E2e smoke exercises both fixtures and generates coverage report via CI
- Upload step uses `if-no-files-found: ignore` for graceful degradation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CI-uploaded smoke coverage report artifact for easier review of test results.

* **Bug Fixes**
  * Improved handling when the smoke coverage file is missing, so CI uploads won’t fail unnecessarily.

* **Documentation**
  * Updated test guidance to describe the report’s output locations, artifact naming, and retention period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->