### PR TITLE
feat: offline real-input preview CLI v1

### DIFF
--- a/scripts/run-real-input-preview.mjs
+++ b/scripts/run-real-input-preview.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+/**
+ * run-real-input-preview.mjs — Offline CLI for running a registered real-input
+ * fixture through the full tutorial preview pipeline.
+ *
+ * Usage:
+ *   node scripts/run-real-input-preview.mjs --fixture <slug> --out <output-dir>
+ *
+ * Pipeline:
+ *   registry lookup → normalize → generate → render → ffprobe → validate → coverage report
+ *
+ * Exit codes:
+ *   0 = success (all steps pass)
+ *   1 = pipeline or validation failure
+ *   2 = invalid arguments or missing fixture
+ */
+
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const require = createRequire(import.meta.url);
+const { loadRegistry, findFixtureBySlug, resolveFixturePaths, validateFixtureFiles } = require('../tests/helpers/realInputFixtureRegistry.cjs');
+const { validateRealInputArtifact } = require('./validate-real-input-preview-artifact.cjs');
+const { createReport, buildFixtureEntry, writeReport } = require('../tests/helpers/realInputSmokeCoverageReport.cjs');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const fixtureSlug = getArg('fixture');
+const outDir = getArg('out');
+
+if (!fixtureSlug || !outDir) {
+  console.error('Usage: node scripts/run-real-input-preview.mjs --fixture <slug> --out <output-dir>');
+  console.error('');
+  console.error('Options:');
+  console.error('  --fixture  Slug of a registered real-input fixture (e.g., sakura-market)');
+  console.error('  --out      Output directory for preview artifacts');
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+const PROJECT_ROOT = resolve(__dirname, '..');
+const REGISTRY_DIR = resolve(PROJECT_ROOT, 'tests/fixtures/tutorial-real-input');
+const REGISTRY_PATH = join(REGISTRY_DIR, 'fixtures.json');
+const NORMALIZER_SCRIPT = resolve(PROJECT_ROOT, 'scripts/normalize-real-input-fixture.cjs');
+const GENERATE_SCRIPT = resolve(PROJECT_ROOT, 'scripts/generate-tutorial-preview.mjs');
+const RENDER_SCRIPT = resolve(PROJECT_ROOT, 'scripts/render-storyboard-ffmpeg.mjs');
+
+const resolvedOut = resolve(outDir);
+
+// ---------------------------------------------------------------------------
+// Step 1: Load registry and find fixture
+// ---------------------------------------------------------------------------
+console.log(`[preview-cli] Loading registry: ${REGISTRY_PATH}`);
+let registry;
+try {
+  registry = loadRegistry(REGISTRY_PATH);
+} catch (err) {
+  console.error(`[preview-cli] Failed to load registry: ${err.message}`);
+  process.exit(2);
+}
+
+const fixture = findFixtureBySlug(registry, fixtureSlug);
+if (!fixture) {
+  console.error(`[preview-cli] Unknown fixture slug: "${fixtureSlug}"`);
+  console.error(`[preview-cli] Available slugs: ${registry.fixtures.map((f) => f.slug).join(', ')}`);
+  process.exit(2);
+}
+
+if (!fixture.enabled) {
+  console.error(`[preview-cli] Fixture "${fixtureSlug}" is disabled in the registry.`);
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Validate fixture files exist
+// ---------------------------------------------------------------------------
+const fileCheck = validateFixtureFiles(fixture, REGISTRY_DIR);
+if (!fileCheck.valid) {
+  console.error(`[preview-cli] Missing fixture files: ${fileCheck.missing.join(', ')}`);
+  process.exit(2);
+}
+
+const paths = resolveFixturePaths(fixture, REGISTRY_DIR);
+console.log(`[preview-cli] Fixture: ${fixture.slug} (${fixture.gameName})`);
+console.log(`[preview-cli] Metadata: ${paths.metadata}`);
+console.log(`[preview-cli] Extract: ${paths.extract}`);
+console.log(`[preview-cli] Expected: ${paths.expected}`);
+console.log(`[preview-cli] Output: ${resolvedOut}`);
+
+// ---------------------------------------------------------------------------
+// Step 3: Create output directory
+// ---------------------------------------------------------------------------
+mkdirSync(resolvedOut, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// Step 4: Normalize
+// ---------------------------------------------------------------------------
+const normalizedPath = join(resolvedOut, `${fixture.slug}-normalized.json`);
+console.log('[preview-cli] Step 1/6: Normalizing fixture...');
+try {
+  execFileSync('node', [
+    NORMALIZER_SCRIPT,
+    '--metadata', paths.metadata,
+    '--extract', paths.extract,
+    '--out', normalizedPath,
+  ], { encoding: 'utf8', stdio: 'pipe', timeout: 15000, cwd: PROJECT_ROOT });
+} catch (err) {
+  console.error(`[preview-cli] Normalization failed: ${err.stderr || err.message}`);
+  process.exit(1);
+}
+console.log(`[preview-cli]   → ${normalizedPath}`);
+
+// ---------------------------------------------------------------------------
+// Step 5: Generate tutorial preview artifacts
+// ---------------------------------------------------------------------------
+console.log('[preview-cli] Step 2/6: Generating tutorial artifacts...');
+try {
+  execFileSync('node', [
+    GENERATE_SCRIPT,
+    '--fixture', normalizedPath,
+    '--slug', fixture.slug,
+    '--out', resolvedOut,
+  ], { encoding: 'utf8', stdio: 'pipe', timeout: 30000, cwd: PROJECT_ROOT });
+} catch (err) {
+  console.error(`[preview-cli] Generation failed: ${err.stderr || err.message}`);
+  process.exit(1);
+}
+console.log('[preview-cli]   → script.json, storyboard.json, captions.srt, render-config.json, manifest.json');
+
+// ---------------------------------------------------------------------------
+// Step 6: Render MP4
+// ---------------------------------------------------------------------------
+const mp4Path = join(resolvedOut, 'preview.mp4');
+console.log('[preview-cli] Step 3/6: Rendering MP4...');
+try {
+  execFileSync('node', [
+    RENDER_SCRIPT,
+    '--config', join(resolvedOut, 'render-config.json'),
+    '--out', mp4Path,
+  ], { encoding: 'utf8', stdio: 'pipe', timeout: 300000, cwd: PROJECT_ROOT });
+} catch (err) {
+  console.error(`[preview-cli] Render failed: ${err.stderr || err.message}`);
+  process.exit(1);
+}
+console.log(`[preview-cli]   → ${mp4Path}`);
+
+// ---------------------------------------------------------------------------
+// Step 7: Capture ffprobe.json
+// ---------------------------------------------------------------------------
+const ffprobePath = join(resolvedOut, 'ffprobe.json');
+console.log('[preview-cli] Step 4/6: Capturing ffprobe metadata...');
+try {
+  const ffprobeOutput = execFileSync('ffprobe', [
+    '-hide_banner', '-loglevel', 'error',
+    '-print_format', 'json',
+    '-show_format', '-show_streams',
+    mp4Path,
+  ], { encoding: 'utf8', stdio: 'pipe', timeout: 15000 });
+  writeFileSync(ffprobePath, ffprobeOutput, 'utf8');
+} catch (err) {
+  console.error(`[preview-cli] ffprobe failed: ${err.stderr || err.message}`);
+  process.exit(1);
+}
+console.log(`[preview-cli]   → ${ffprobePath}`);
+
+// ---------------------------------------------------------------------------
+// Step 8: Validate against contract
+// ---------------------------------------------------------------------------
+console.log('[preview-cli] Step 5/6: Validating artifact contract...');
+const expectedContract = JSON.parse(readFileSync(paths.expected, 'utf8'));
+const validationResult = validateRealInputArtifact(resolvedOut, expectedContract);
+
+const validationOutputPath = join(resolvedOut, 'validation-result.json');
+writeFileSync(validationOutputPath, JSON.stringify(validationResult, null, 2), 'utf8');
+
+if (validationResult.passed) {
+  console.log('[preview-cli]   → Contract validation PASSED');
+} else {
+  console.error(`[preview-cli]   → Contract validation FAILED (${validationResult.errors.length} error(s)):`);
+  validationResult.errors.forEach((e) => console.error(`      - ${e}`));
+}
+
+// ---------------------------------------------------------------------------
+// Step 9: Write coverage report
+// ---------------------------------------------------------------------------
+console.log('[preview-cli] Step 6/6: Writing coverage report...');
+const ffprobeData = existsSync(ffprobePath) ? JSON.parse(readFileSync(ffprobePath, 'utf8')) : null;
+const manifestData = existsSync(join(resolvedOut, 'manifest.json'))
+  ? JSON.parse(readFileSync(join(resolvedOut, 'manifest.json'), 'utf8'))
+  : null;
+
+const report = createReport({ registryPath: REGISTRY_PATH, enabledCount: 1 });
+const entry = buildFixtureEntry({
+  slug: fixture.slug,
+  gameName: fixture.gameName,
+  profile: fixture.profile,
+  metadataFile: fixture.metadataFile,
+  rulebookExtractFile: fixture.rulebookExtractFile,
+  expectedFile: fixture.expectedFile,
+  normalizedFixturePath: normalizedPath,
+  artifactDir: resolvedOut,
+  ffprobeData,
+  manifestData,
+  requiredArtifacts: expectedContract.requiredArtifacts || [],
+  contractValidation: validationResult,
+});
+report.fixtures.push(entry);
+
+const coverageReportPath = join(resolvedOut, 'real-input-preview-coverage.json');
+writeReport(coverageReportPath, report);
+console.log(`[preview-cli]   → ${coverageReportPath}`);
+
+// ---------------------------------------------------------------------------
+// Final summary
+// ---------------------------------------------------------------------------
+console.log('');
+if (validationResult.passed) {
+  console.log(`[preview-cli] SUCCESS: ${fixture.slug} preview pipeline completed.`);
+  console.log(`[preview-cli] Output directory: ${resolvedOut}`);
+  process.exit(0);
+} else {
+  console.error(`[preview-cli] COMPLETED WITH VALIDATION FAILURES: ${validationResult.errors.length} contract violation(s).`);
+  console.error(`[preview-cli] Output directory: ${resolvedOut}`);
+  process.exit(1);
+}

--- a/tests/fixtures/tutorial-real-input/README.md
+++ b/tests/fixtures/tutorial-real-input/README.md
@@ -261,3 +261,72 @@ smoke was skipped (e.g., on a machine without FFmpeg during local development).
 
 The report generation logic is in `tests/helpers/realInputSmokeCoverageReport.cjs`
 with unit tests at `tests/scripts/realInputSmokeCoverageReport.test.js`.
+
+## Offline Preview CLI
+
+Run a registered fixture through the full offline pipeline on demand:
+
+```bash
+node scripts/run-real-input-preview.mjs --fixture sakura-market --out out/real-input-previews/sakura-market
+node scripts/run-real-input-preview.mjs --fixture stellar-drift --out out/real-input-previews/stellar-drift
+```
+
+### Requirements
+
+- Node.js 20+
+- FFmpeg with drawtext filter on PATH
+
+### Pipeline steps
+
+1. Load `fixtures.json` registry and find the fixture by slug
+2. Validate fixture files exist on disk
+3. Normalize metadata + rulebook-extract into canonical fixture
+4. Generate tutorial preview artifacts (script, storyboard, captions, render-config, manifest)
+5. Render `preview.mp4` via FFmpeg
+6. Capture `ffprobe.json` media metadata
+7. Validate against the fixture's expected contract
+8. Write `real-input-preview-coverage.json` coverage report
+
+### Output directory contents
+
+```
+<out>/
+  <slug>-normalized.json       # Canonical fixture from normalizer
+  script.json                   # Tutorial script
+  storyboard.json               # Storyboard scenes
+  captions.srt                  # SRT captions
+  render-config.json            # FFmpeg render configuration
+  manifest.json                 # Generation manifest with identity
+  preview.mp4                   # Rendered tutorial preview video
+  ffprobe.json                  # Media metadata from ffprobe
+  validation-result.json        # Contract validation result
+  real-input-preview-coverage.json  # Coverage report for this run
+```
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All steps passed, contract validation succeeded |
+| 1 | Pipeline or validation failure (render failed, contract violated, etc.) |
+| 2 | Invalid arguments (missing --fixture/--out, unknown slug, disabled fixture) |
+
+### Error examples
+
+```bash
+# Missing arguments
+$ node scripts/run-real-input-preview.mjs
+# → exit 2, prints usage
+
+# Unknown fixture
+$ node scripts/run-real-input-preview.mjs --fixture bad-slug --out /tmp/x
+# → exit 2, prints "Unknown fixture slug" + available slugs
+```
+
+### Shared helpers
+
+| Module | Role |
+|--------|------|
+| `tests/helpers/realInputFixtureRegistry.cjs` | Registry loading, fixture lookup, path resolution, file validation |
+| `scripts/validate-real-input-preview-artifact.cjs` | Contract validation |
+| `tests/helpers/realInputSmokeCoverageReport.cjs` | Coverage report generation |

--- a/tests/helpers/realInputFixtureRegistry.cjs
+++ b/tests/helpers/realInputFixtureRegistry.cjs
@@ -1,0 +1,96 @@
+/**
+ * realInputFixtureRegistry.cjs — Shared registry loading and lookup helper.
+ *
+ * Used by both the E2E smoke test and the offline preview CLI to discover
+ * and resolve real-input fixtures from fixtures.json.
+ *
+ * Dependency-free, cross-platform.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_REGISTRY_PATH = path.resolve(__dirname, '../fixtures/tutorial-real-input/fixtures.json');
+
+/**
+ * Load the fixture registry from disk.
+ * @param {string} [registryPath] - Override path to fixtures.json (defaults to workspace registry)
+ * @returns {object} Parsed registry object
+ * @throws {Error} If file not found or invalid JSON
+ */
+function loadRegistry(registryPath) {
+  const resolvedPath = registryPath || DEFAULT_REGISTRY_PATH;
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Registry file not found: ${resolvedPath}`);
+  }
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  let registry;
+  try {
+    registry = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Invalid JSON in registry file: ${err.message}`);
+  }
+  if (!Array.isArray(registry.fixtures)) {
+    throw new Error('Registry must contain a "fixtures" array');
+  }
+  return registry;
+}
+
+/**
+ * Get all enabled fixtures from the registry.
+ * @param {object} registry - Parsed registry object
+ * @returns {object[]} Array of enabled fixture entries
+ */
+function getEnabledFixtures(registry) {
+  return registry.fixtures.filter((f) => f.enabled);
+}
+
+/**
+ * Find a fixture by slug from the registry.
+ * @param {object} registry - Parsed registry object
+ * @param {string} slug - Fixture slug to find
+ * @returns {object|null} Fixture entry or null if not found
+ */
+function findFixtureBySlug(registry, slug) {
+  return registry.fixtures.find((f) => f.slug === slug) || null;
+}
+
+/**
+ * Resolve fixture file paths relative to a registry directory.
+ * @param {object} fixture - Fixture registry entry
+ * @param {string} registryDir - Absolute path to the registry directory
+ * @returns {object} Resolved paths: { metadata, extract, expected }
+ */
+function resolveFixturePaths(fixture, registryDir) {
+  return {
+    metadata: path.join(registryDir, fixture.metadataFile),
+    extract: path.join(registryDir, fixture.rulebookExtractFile),
+    expected: path.join(registryDir, fixture.expectedFile),
+  };
+}
+
+/**
+ * Validate that a fixture's required files exist on disk.
+ * @param {object} fixture - Fixture registry entry
+ * @param {string} registryDir - Absolute path to the registry directory
+ * @returns {{ valid: boolean, missing: string[] }}
+ */
+function validateFixtureFiles(fixture, registryDir) {
+  const paths = resolveFixturePaths(fixture, registryDir);
+  const missing = [];
+  if (!fs.existsSync(paths.metadata)) missing.push(fixture.metadataFile);
+  if (!fs.existsSync(paths.extract)) missing.push(fixture.rulebookExtractFile);
+  if (!fs.existsSync(paths.expected)) missing.push(fixture.expectedFile);
+  return { valid: missing.length === 0, missing };
+}
+
+module.exports = {
+  DEFAULT_REGISTRY_PATH,
+  loadRegistry,
+  getEnabledFixtures,
+  findFixtureBySlug,
+  resolveFixturePaths,
+  validateFixtureFiles,
+};

--- a/tests/scripts/runRealInputPreview.test.js
+++ b/tests/scripts/runRealInputPreview.test.js
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for the offline real-input preview CLI helpers and argument handling.
+ *
+ * Tests registry helper functions (realInputFixtureRegistry.cjs) and CLI
+ * error behavior without requiring FFmpeg for unit-level validation.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+const {
+  loadRegistry,
+  getEnabledFixtures,
+  findFixtureBySlug,
+  resolveFixturePaths,
+  validateFixtureFiles,
+  DEFAULT_REGISTRY_PATH,
+} = require('../helpers/realInputFixtureRegistry.cjs');
+
+const CLI_SCRIPT = path.resolve(__dirname, '../../scripts/run-real-input-preview.mjs');
+const REGISTRY_DIR = path.resolve(__dirname, '../fixtures/tutorial-real-input');
+
+// ---------------------------------------------------------------------------
+// Registry helper tests
+// ---------------------------------------------------------------------------
+describe('realInputFixtureRegistry — loadRegistry', () => {
+  test('loads the workspace registry successfully', () => {
+    const registry = loadRegistry();
+    expect(registry).toBeDefined();
+    expect(Array.isArray(registry.fixtures)).toBe(true);
+    expect(registry.fixtures.length).toBeGreaterThan(0);
+  });
+
+  test('loads from explicit path', () => {
+    const registry = loadRegistry(DEFAULT_REGISTRY_PATH);
+    expect(Array.isArray(registry.fixtures)).toBe(true);
+  });
+
+  test('throws on missing file', () => {
+    expect(() => loadRegistry('/nonexistent/path/fixtures.json')).toThrow('not found');
+  });
+
+  test('throws on invalid JSON', () => {
+    const tmpFile = path.join(os.tmpdir(), 'bad-registry.json');
+    fs.writeFileSync(tmpFile, '{broken', 'utf8');
+    try {
+      expect(() => loadRegistry(tmpFile)).toThrow('Invalid JSON');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  test('throws when fixtures array is missing', () => {
+    const tmpFile = path.join(os.tmpdir(), 'no-fixtures.json');
+    fs.writeFileSync(tmpFile, '{"_schema":"test"}', 'utf8');
+    try {
+      expect(() => loadRegistry(tmpFile)).toThrow('fixtures');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+});
+
+describe('realInputFixtureRegistry — getEnabledFixtures', () => {
+  test('returns only enabled fixtures', () => {
+    const registry = loadRegistry();
+    const enabled = getEnabledFixtures(registry);
+    expect(enabled.length).toBeGreaterThan(0);
+    for (const f of enabled) {
+      expect(f.enabled).toBe(true);
+    }
+  });
+
+  test('returns empty for all-disabled registry', () => {
+    const registry = { fixtures: [{ slug: 'x', enabled: false }] };
+    expect(getEnabledFixtures(registry)).toHaveLength(0);
+  });
+});
+
+describe('realInputFixtureRegistry — findFixtureBySlug', () => {
+  test('finds sakura-market', () => {
+    const registry = loadRegistry();
+    const fixture = findFixtureBySlug(registry, 'sakura-market');
+    expect(fixture).not.toBeNull();
+    expect(fixture.slug).toBe('sakura-market');
+    expect(fixture.gameName).toBe('Sakura Market');
+  });
+
+  test('finds stellar-drift', () => {
+    const registry = loadRegistry();
+    const fixture = findFixtureBySlug(registry, 'stellar-drift');
+    expect(fixture).not.toBeNull();
+    expect(fixture.slug).toBe('stellar-drift');
+  });
+
+  test('returns null for unknown slug', () => {
+    const registry = loadRegistry();
+    expect(findFixtureBySlug(registry, 'nonexistent-game')).toBeNull();
+  });
+});
+
+describe('realInputFixtureRegistry — resolveFixturePaths', () => {
+  test('resolves paths relative to registry directory', () => {
+    const fixture = { metadataFile: 'a.json', rulebookExtractFile: 'b.json', expectedFile: 'c.json' };
+    const resolved = resolveFixturePaths(fixture, '/base/dir');
+    expect(resolved.metadata).toBe(path.join('/base/dir', 'a.json'));
+    expect(resolved.extract).toBe(path.join('/base/dir', 'b.json'));
+    expect(resolved.expected).toBe(path.join('/base/dir', 'c.json'));
+  });
+});
+
+describe('realInputFixtureRegistry — validateFixtureFiles', () => {
+  test('returns valid for sakura-market', () => {
+    const registry = loadRegistry();
+    const fixture = findFixtureBySlug(registry, 'sakura-market');
+    const result = validateFixtureFiles(fixture, REGISTRY_DIR);
+    expect(result.valid).toBe(true);
+    expect(result.missing).toHaveLength(0);
+  });
+
+  test('returns invalid when files are missing', () => {
+    const fixture = { metadataFile: 'missing.json', rulebookExtractFile: 'also-missing.json', expectedFile: 'nope.json' };
+    const result = validateFixtureFiles(fixture, REGISTRY_DIR);
+    expect(result.valid).toBe(false);
+    expect(result.missing).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI argument error handling tests (no FFmpeg required)
+// ---------------------------------------------------------------------------
+describe('run-real-input-preview CLI — argument errors', () => {
+  function runCLI(args) {
+    try {
+      const result = execFileSync('node', [CLI_SCRIPT, ...args], {
+        encoding: 'utf8',
+        stdio: 'pipe',
+        timeout: 10000,
+        cwd: path.resolve(__dirname, '../..'),
+      });
+      return { exitCode: 0, stdout: result, stderr: '' };
+    } catch (err) {
+      return { exitCode: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+    }
+  }
+
+  test('exits 2 with no arguments', () => {
+    const { exitCode, stderr } = runCLI([]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Usage');
+  });
+
+  test('exits 2 with --fixture but no --out', () => {
+    const { exitCode, stderr } = runCLI(['--fixture', 'sakura-market']);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Usage');
+  });
+
+  test('exits 2 with --out but no --fixture', () => {
+    const { exitCode, stderr } = runCLI(['--out', '/tmp/test-out']);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Usage');
+  });
+
+  test('exits 2 for unknown fixture slug', () => {
+    const { exitCode, stderr } = runCLI(['--fixture', 'nonexistent-game', '--out', '/tmp/test-out']);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Unknown fixture slug');
+    expect(stderr).toContain('nonexistent-game');
+  });
+
+  test('prints available slugs for unknown fixture', () => {
+    const { stderr } = runCLI(['--fixture', 'bad-slug', '--out', '/tmp/test-out']);
+    expect(stderr).toContain('sakura-market');
+    expect(stderr).toContain('stellar-drift');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an operator-facing offline CLI that runs a registered real-input fixture through the full tutorial preview pipeline on demand. Reuses existing normalizer, generator, renderer, validator, and coverage-report helpers.

## Changes

- **`scripts/run-real-input-preview.mjs`** — CLI orchestrating the full pipeline: registry lookup, normalize, generate, render, ffprobe, validate, coverage report
- **`tests/helpers/realInputFixtureRegistry.cjs`** — Shared registry helper (loadRegistry, findFixtureBySlug, resolveFixturePaths, validateFixtureFiles)
- **`tests/scripts/runRealInputPreview.test.js`** — 18 unit tests for registry helper and CLI argument error handling
- **`tests/fixtures/tutorial-real-input/README.md`** — CLI documentation (usage, output layout, exit codes, shared helpers)

## CLI usage

```bash
node scripts/run-real-input-preview.mjs --fixture sakura-market --out out/real-input-previews/sakura-market
node scripts/run-real-input-preview.mjs --fixture stellar-drift --out out/real-input-previews/stellar-drift
```

## Pipeline steps

1. Load registry and find fixture by slug
2. Validate fixture files exist
3. Normalize metadata + rulebook-extract → canonical fixture
4. Generate tutorial artifacts
5. Render preview.mp4
6. Capture ffprobe.json
7. Validate against expected contract
8. Write coverage report

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | All steps passed |
| 1 | Pipeline or validation failure |
| 2 | Invalid arguments, unknown/disabled fixture |

## What stays unchanged

- E2E smoke (still runs both fixtures via registry)
- CI coverage artifact publishing
- Deterministic gem-collectors smoke
- Normalizer, validator, renderer logic
- Golden baselines and workflow triggers

## Testing

- 18 CLI/registry unit tests pass (no FFmpeg required)
- Full local suite: 52 suites, 576 tests (575 passed, 1 skipped)
- CLI exercised locally via unit tests; full pipeline runs in CI via existing smoke
