### PR TITLE
feat: real-input source contract validator v1

### DIFF
--- a/scripts/run-real-input-preview.mjs
+++ b/scripts/run-real-input-preview.mjs
@@ -28,6 +28,7 @@ const __dirname = dirname(__filename);
 const require = createRequire(import.meta.url);
 const { loadRegistry, findFixtureBySlug, resolveFixturePaths, validateFixtureFiles } = require('../tests/helpers/realInputFixtureRegistry.cjs');
 const { validateRealInputArtifact } = require('./validate-real-input-preview-artifact.cjs');
+const { validateSourceContract } = require('./validate-real-input-source-contract.cjs');
 const { createReport, buildFixtureEntry, writeReport } = require('../tests/helpers/realInputSmokeCoverageReport.cjs');
 
 // ---------------------------------------------------------------------------
@@ -104,6 +105,20 @@ console.log(`[preview-cli] Metadata: ${paths.metadata}`);
 console.log(`[preview-cli] Extract: ${paths.extract}`);
 console.log(`[preview-cli] Expected: ${paths.expected}`);
 console.log(`[preview-cli] Output: ${resolvedOut}`);
+
+// ---------------------------------------------------------------------------
+// Step 2b: Validate source contracts before normalization
+// ---------------------------------------------------------------------------
+console.log('[preview-cli] Validating source contracts...');
+const metadataJson = JSON.parse(readFileSync(paths.metadata, 'utf8'));
+const extractJson = JSON.parse(readFileSync(paths.extract, 'utf8'));
+const sourceResult = validateSourceContract(metadataJson, extractJson, fixture);
+if (!sourceResult.passed) {
+  console.error(`[preview-cli] Source contract validation FAILED (${sourceResult.errors.length} error(s)):`);
+  sourceResult.errors.forEach((e) => console.error(`  - ${e}`));
+  process.exit(1);
+}
+console.log('[preview-cli]   → Source contracts valid');
 
 // ---------------------------------------------------------------------------
 // Step 3: Create output directory

--- a/scripts/validate-real-input-source-contract.cjs
+++ b/scripts/validate-real-input-source-contract.cjs
@@ -1,0 +1,292 @@
+/**
+ * validate-real-input-source-contract.cjs — Source contract validator for
+ * real-input fixture metadata and rulebook-extract files.
+ *
+ * Validates source inputs before normalization to catch structural issues
+ * early, before the CLI or E2E smoke attempts rendering.
+ *
+ * Usage:
+ *   node scripts/validate-real-input-source-contract.cjs --fixture sakura-market
+ *   node scripts/validate-real-input-source-contract.cjs --all
+ *
+ * Exit codes:
+ *   0 = all checks pass
+ *   1 = one or more contract violations found
+ *   2 = invalid arguments or missing registry
+ *
+ * Programmatic API:
+ *   const { validateMetadata, validateRulebookExtract, validateSourceContract } = require('./validate-real-input-source-contract.cjs');
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Metadata contract validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a metadata object against the source contract.
+ * @param {object} metadata - Parsed metadata JSON
+ * @returns {{ passed: boolean, errors: string[] }}
+ */
+function validateMetadata(metadata) {
+  const errors = [];
+
+  if (!metadata || typeof metadata !== 'object') {
+    return { passed: false, errors: ['Metadata must be a non-null object'] };
+  }
+
+  // Required string fields
+  const requiredStrings = ['slug', 'title'];
+  for (const field of requiredStrings) {
+    if (typeof metadata[field] !== 'string' || metadata[field].length === 0) {
+      errors.push(`metadata.${field} must be a non-empty string`);
+    }
+  }
+
+  // playerCount structure
+  if (!metadata.playerCount || typeof metadata.playerCount !== 'object') {
+    errors.push('metadata.playerCount must be an object');
+  } else {
+    if (typeof metadata.playerCount.min !== 'number' || metadata.playerCount.min < 1) {
+      errors.push('metadata.playerCount.min must be a positive number');
+    }
+    if (typeof metadata.playerCount.max !== 'number' || metadata.playerCount.max < 1) {
+      errors.push('metadata.playerCount.max must be a positive number');
+    }
+    if (metadata.playerCount.min > metadata.playerCount.max) {
+      errors.push('metadata.playerCount.min must not exceed metadata.playerCount.max');
+    }
+  }
+
+  // designers array
+  if (!Array.isArray(metadata.designers) || metadata.designers.length === 0) {
+    errors.push('metadata.designers must be a non-empty array');
+  } else {
+    for (let i = 0; i < metadata.designers.length; i++) {
+      if (typeof metadata.designers[i] !== 'string' || metadata.designers[i].length === 0) {
+        errors.push(`metadata.designers[${i}] must be a non-empty string`);
+      }
+    }
+  }
+
+  // playtimeMinutes structure (optional but if present must be valid)
+  if (metadata.playtimeMinutes) {
+    if (typeof metadata.playtimeMinutes !== 'object') {
+      errors.push('metadata.playtimeMinutes must be an object if present');
+    } else {
+      if (typeof metadata.playtimeMinutes.min !== 'number' || metadata.playtimeMinutes.min < 0) {
+        errors.push('metadata.playtimeMinutes.min must be a non-negative number');
+      }
+      if (typeof metadata.playtimeMinutes.max !== 'number' || metadata.playtimeMinutes.max < 0) {
+        errors.push('metadata.playtimeMinutes.max must be a non-negative number');
+      }
+    }
+  }
+
+  // description (optional but if present must be string)
+  if (metadata.description !== undefined && typeof metadata.description !== 'string') {
+    errors.push('metadata.description must be a string if present');
+  }
+
+  return { passed: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Rulebook-extract contract validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a rulebook-extract object against the source contract.
+ * @param {object} extract - Parsed rulebook-extract JSON
+ * @returns {{ passed: boolean, errors: string[] }}
+ */
+function validateRulebookExtract(extract) {
+  const errors = [];
+
+  if (!extract || typeof extract !== 'object') {
+    return { passed: false, errors: ['Rulebook extract must be a non-null object'] };
+  }
+
+  // objective: required non-empty string
+  if (typeof extract.objective !== 'string' || extract.objective.length === 0) {
+    errors.push('extract.objective must be a non-empty string');
+  }
+
+  // components: required non-empty array of objects with name
+  if (!Array.isArray(extract.components) || extract.components.length === 0) {
+    errors.push('extract.components must be a non-empty array');
+  } else {
+    for (let i = 0; i < extract.components.length; i++) {
+      const comp = extract.components[i];
+      if (!comp || typeof comp !== 'object') {
+        errors.push(`extract.components[${i}] must be an object`);
+      } else if (typeof comp.name !== 'string' || comp.name.length === 0) {
+        errors.push(`extract.components[${i}].name must be a non-empty string`);
+      }
+    }
+  }
+
+  // setup: required non-empty array of strings
+  if (!Array.isArray(extract.setup) || extract.setup.length === 0) {
+    errors.push('extract.setup must be a non-empty array');
+  } else {
+    for (let i = 0; i < extract.setup.length; i++) {
+      if (typeof extract.setup[i] !== 'string' || extract.setup[i].length === 0) {
+        errors.push(`extract.setup[${i}] must be a non-empty string`);
+      }
+    }
+  }
+
+  // turnStructure: required object with phases array and description
+  if (!extract.turnStructure || typeof extract.turnStructure !== 'object') {
+    errors.push('extract.turnStructure must be an object');
+  } else {
+    if (!Array.isArray(extract.turnStructure.phases) || extract.turnStructure.phases.length === 0) {
+      errors.push('extract.turnStructure.phases must be a non-empty array');
+    }
+    if (typeof extract.turnStructure.description !== 'string' || extract.turnStructure.description.length === 0) {
+      errors.push('extract.turnStructure.description must be a non-empty string');
+    }
+  }
+
+  // coreMechanic: required object with name and description
+  if (!extract.coreMechanic || typeof extract.coreMechanic !== 'object') {
+    errors.push('extract.coreMechanic must be an object');
+  } else {
+    if (typeof extract.coreMechanic.name !== 'string' || extract.coreMechanic.name.length === 0) {
+      errors.push('extract.coreMechanic.name must be a non-empty string');
+    }
+    if (typeof extract.coreMechanic.description !== 'string' || extract.coreMechanic.description.length === 0) {
+      errors.push('extract.coreMechanic.description must be a non-empty string');
+    }
+  }
+
+  // scoring: required object with winCondition
+  if (!extract.scoring || typeof extract.scoring !== 'object') {
+    errors.push('extract.scoring must be an object');
+  } else {
+    if (typeof extract.scoring.winCondition !== 'string' || extract.scoring.winCondition.length === 0) {
+      errors.push('extract.scoring.winCondition must be a non-empty string');
+    }
+  }
+
+  return { passed: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Combined source contract validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a complete source contract (metadata + rulebook-extract + identity consistency).
+ * @param {object} metadata - Parsed metadata JSON
+ * @param {object} extract - Parsed rulebook-extract JSON
+ * @param {object} [registryEntry] - Optional registry entry for identity consistency checks
+ * @returns {{ passed: boolean, errors: string[] }}
+ */
+function validateSourceContract(metadata, extract, registryEntry) {
+  const metaResult = validateMetadata(metadata);
+  const extractResult = validateRulebookExtract(extract);
+  const errors = [...metaResult.errors, ...extractResult.errors];
+
+  // Identity consistency with registry entry
+  if (registryEntry && metadata && typeof metadata === 'object') {
+    if (metadata.slug !== registryEntry.slug) {
+      errors.push(`Identity mismatch: metadata.slug "${metadata.slug}" !== registry slug "${registryEntry.slug}"`);
+    }
+    if (metadata.title !== registryEntry.gameName) {
+      errors.push(`Identity mismatch: metadata.title "${metadata.title}" !== registry gameName "${registryEntry.gameName}"`);
+    }
+  }
+
+  return { passed: errors.length === 0, errors };
+}
+
+module.exports = { validateMetadata, validateRulebookExtract, validateSourceContract };
+
+// ---------------------------------------------------------------------------
+// CLI mode
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const { loadRegistry, getEnabledFixtures, findFixtureBySlug, resolveFixturePaths } = require('../tests/helpers/realInputFixtureRegistry.cjs');
+
+  const args = process.argv.slice(2);
+  function getArg(name) {
+    const idx = args.indexOf(`--${name}`);
+    if (idx === -1 || idx + 1 >= args.length) return null;
+    return args[idx + 1];
+  }
+  const isAll = args.includes('--all');
+  const fixtureSlug = getArg('fixture');
+
+  if (!isAll && !fixtureSlug) {
+    console.error('Usage:');
+    console.error('  node scripts/validate-real-input-source-contract.cjs --all');
+    console.error('  node scripts/validate-real-input-source-contract.cjs --fixture <slug>');
+    process.exit(2);
+  }
+
+  let registry;
+  try {
+    registry = loadRegistry();
+  } catch (err) {
+    console.error(`[source-contract] Failed to load registry: ${err.message}`);
+    process.exit(2);
+  }
+
+  const REGISTRY_DIR = path.resolve(__dirname, '../tests/fixtures/tutorial-real-input');
+  const fixtures = isAll ? getEnabledFixtures(registry) : (() => {
+    const f = findFixtureBySlug(registry, fixtureSlug);
+    if (!f) {
+      console.error(`[source-contract] Unknown fixture slug: "${fixtureSlug}"`);
+      console.error(`[source-contract] Available: ${registry.fixtures.map((x) => x.slug).join(', ')}`);
+      process.exit(2);
+    }
+    return [f];
+  })();
+
+  let totalErrors = 0;
+
+  for (const fixture of fixtures) {
+    const paths = resolveFixturePaths(fixture, REGISTRY_DIR);
+    console.log(`[source-contract] Validating: ${fixture.slug}`);
+
+    let metadata, extract;
+    try {
+      metadata = JSON.parse(fs.readFileSync(paths.metadata, 'utf8'));
+    } catch (err) {
+      console.error(`  metadata: PARSE ERROR — ${err.message}`);
+      totalErrors++;
+      continue;
+    }
+    try {
+      extract = JSON.parse(fs.readFileSync(paths.extract, 'utf8'));
+    } catch (err) {
+      console.error(`  rulebook-extract: PARSE ERROR — ${err.message}`);
+      totalErrors++;
+      continue;
+    }
+
+    const result = validateSourceContract(metadata, extract, fixture);
+    if (result.passed) {
+      console.log(`  ✓ PASSED`);
+    } else {
+      console.error(`  ✗ FAILED (${result.errors.length} error(s)):`);
+      result.errors.forEach((e) => console.error(`    - ${e}`));
+      totalErrors += result.errors.length;
+    }
+  }
+
+  console.log('');
+  if (totalErrors === 0) {
+    console.log(`[source-contract] ALL PASSED (${fixtures.length} fixture(s) validated)`);
+    process.exit(0);
+  } else {
+    console.error(`[source-contract] FAILED: ${totalErrors} total error(s) across ${fixtures.length} fixture(s)`);
+    process.exit(1);
+  }
+}

--- a/tests/e2e/tutorial_full_flow_smoke.test.js
+++ b/tests/e2e/tutorial_full_flow_smoke.test.js
@@ -21,6 +21,7 @@ const VALIDATE_REAL_INPUT_SCRIPT = path.resolve(__dirname, '../../scripts/valida
 const FIXTURE = path.resolve(__dirname, '../fixtures/tutorial-vertical-slice/gem-collectors.json');
 const NORMALIZER_SCRIPT = path.resolve(__dirname, '../../scripts/normalize-real-input-fixture.cjs');
 const { validateRealInputArtifact } = require('../../scripts/validate-real-input-preview-artifact.cjs');
+const { validateSourceContract } = require('../../scripts/validate-real-input-source-contract.cjs');
 const { createReport, buildFixtureEntry, writeReport } = require('../helpers/realInputSmokeCoverageReport.cjs');
 
 // ---------------------------------------------------------------------------
@@ -274,7 +275,18 @@ describe.each(REAL_INPUT_MATRIX)('Real-Input Smoke ($slug → MP4)', (fixtureEnt
     outDir = path.join(tmpDir, `tutorial-preview-${fixtureEntry.slug}`);
     mp4Path = path.join(outDir, 'preview.mp4');
 
-    // Step 0: Normalize metadata + rulebook-extract into canonical fixture
+    // Step 0: Validate source contracts before normalization
+    const metadataJson = JSON.parse(fs.readFileSync(fixtureEntry.metadata, 'utf8'));
+    const extractJson = JSON.parse(fs.readFileSync(fixtureEntry.extract, 'utf8'));
+    const sourceResult = validateSourceContract(metadataJson, extractJson, {
+      slug: fixtureEntry.slug,
+      gameName: fixtureEntry.gameName,
+    });
+    if (!sourceResult.passed) {
+      throw new Error(`Source contract validation failed for ${fixtureEntry.slug}: ${sourceResult.errors.join('; ')}`);
+    }
+
+    // Step 1: Normalize metadata + rulebook-extract into canonical fixture
     normalizedFixturePath = path.join(tmpDir, `${fixtureEntry.slug}-normalized.json`);
     execFileSync('node', [
       NORMALIZER_SCRIPT,

--- a/tests/fixtures/tutorial-real-input/README.md
+++ b/tests/fixtures/tutorial-real-input/README.md
@@ -341,6 +341,58 @@ orchestration works outside the test harness:
 node scripts/run-real-input-preview.mjs --fixture sakura-market --out out/real-input-cli-smoke/sakura-market
 ```
 
+## Source Contract Validation
+
+Before normalization, both the CLI and E2E smoke validate source inputs against
+a structural contract. This catches malformed or incomplete fixture files before
+the pipeline attempts rendering.
+
+### Validation command
+
+```bash
+# Validate all enabled fixtures
+node scripts/validate-real-input-source-contract.cjs --all
+
+# Validate one fixture by slug
+node scripts/validate-real-input-source-contract.cjs --fixture sakura-market
+```
+
+### Metadata contract rules
+
+| Field | Requirement |
+|-------|-------------|
+| `slug` | Non-empty string |
+| `title` | Non-empty string |
+| `playerCount` | Object with `min` and `max` (positive numbers, min <= max) |
+| `designers` | Non-empty array of non-empty strings |
+| `playtimeMinutes` | Optional; if present, object with non-negative `min` and `max` |
+| `description` | Optional; if present, must be a string |
+
+### Rulebook-extract contract rules
+
+| Field | Requirement |
+|-------|-------------|
+| `objective` | Non-empty string |
+| `components` | Non-empty array of objects with `name` (non-empty string) |
+| `setup` | Non-empty array of non-empty strings |
+| `turnStructure` | Object with `phases` (non-empty array) and `description` (non-empty string) |
+| `coreMechanic` | Object with `name` and `description` (both non-empty strings) |
+| `scoring` | Object with `winCondition` (non-empty string) |
+
+### Identity consistency
+
+When a registry entry is provided, the validator also checks:
+- `metadata.slug` matches `registry.slug`
+- `metadata.title` matches `registry.gameName`
+
+### Integration points
+
+- **Offline CLI** (`scripts/run-real-input-preview.mjs`) — validates before normalization; exits 1 on failure
+- **E2E smoke** (`tests/e2e/tutorial_full_flow_smoke.test.js`) — validates in `beforeAll` before each fixture is normalized/rendered
+- **Standalone CLI** (`scripts/validate-real-input-source-contract.cjs`) — validates one or all fixtures independently
+
+## CI CLI Smoke (continued)
+
 This runs in every `build-and-qa` job (Ubuntu, Windows, macOS) and:
 - Proves the CLI can load the registry, normalize, generate, render, probe, validate, and report
 - Verifies all 10 expected output files exist after the run

--- a/tests/scripts/validateRealInputSourceContract.test.js
+++ b/tests/scripts/validateRealInputSourceContract.test.js
@@ -1,0 +1,326 @@
+/**
+ * Unit tests for validate-real-input-source-contract.cjs
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+const {
+  validateMetadata,
+  validateRulebookExtract,
+  validateSourceContract,
+} = require('../../scripts/validate-real-input-source-contract.cjs');
+
+const CLI_SCRIPT = path.resolve(__dirname, '../../scripts/validate-real-input-source-contract.cjs');
+
+// ---------------------------------------------------------------------------
+// Helpers: valid baseline objects
+// ---------------------------------------------------------------------------
+function validMetadata() {
+  return {
+    slug: 'test-game',
+    title: 'Test Game',
+    playerCount: { min: 2, max: 4 },
+    designers: ['Author One'],
+    playtimeMinutes: { min: 30, max: 45 },
+    description: 'A test game.',
+  };
+}
+
+function validExtract() {
+  return {
+    objective: 'Win the game by scoring points.',
+    components: [{ name: 'Cards', quantity: 50, category: 'cards' }],
+    setup: ['Place the board in the center.'],
+    turnStructure: {
+      phases: ['Draw', 'Play'],
+      description: 'Draw a card, then play a card.',
+      endCondition: 'Deck runs out.',
+    },
+    coreMechanic: { name: 'Card Play', description: 'Play cards to score.' },
+    scoring: { description: 'Count points.', winCondition: 'Most points wins.' },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateMetadata
+// ---------------------------------------------------------------------------
+describe('validateMetadata', () => {
+  test('passes with valid metadata', () => {
+    const result = validateMetadata(validMetadata());
+    expect(result.passed).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('fails on null', () => {
+    const result = validateMetadata(null);
+    expect(result.passed).toBe(false);
+    expect(result.errors[0]).toContain('non-null object');
+  });
+
+  test('fails on missing slug', () => {
+    const meta = validMetadata();
+    delete meta.slug;
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('slug'))).toBe(true);
+  });
+
+  test('fails on empty title', () => {
+    const meta = validMetadata();
+    meta.title = '';
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('title'))).toBe(true);
+  });
+
+  test('fails on missing playerCount', () => {
+    const meta = validMetadata();
+    delete meta.playerCount;
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('playerCount'))).toBe(true);
+  });
+
+  test('fails on playerCount.min > playerCount.max', () => {
+    const meta = validMetadata();
+    meta.playerCount = { min: 5, max: 2 };
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('must not exceed'))).toBe(true);
+  });
+
+  test('fails on empty designers array', () => {
+    const meta = validMetadata();
+    meta.designers = [];
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('designers'))).toBe(true);
+  });
+
+  test('fails on designer with empty string', () => {
+    const meta = validMetadata();
+    meta.designers = ['Good', ''];
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('designers[1]'))).toBe(true);
+  });
+
+  test('fails on invalid playtimeMinutes', () => {
+    const meta = validMetadata();
+    meta.playtimeMinutes = { min: -5, max: 30 };
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('playtimeMinutes.min'))).toBe(true);
+  });
+
+  test('passes without playtimeMinutes (optional)', () => {
+    const meta = validMetadata();
+    delete meta.playtimeMinutes;
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(true);
+  });
+
+  test('fails on non-string description', () => {
+    const meta = validMetadata();
+    meta.description = 123;
+    const result = validateMetadata(meta);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('description'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateRulebookExtract
+// ---------------------------------------------------------------------------
+describe('validateRulebookExtract', () => {
+  test('passes with valid extract', () => {
+    const result = validateRulebookExtract(validExtract());
+    expect(result.passed).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('fails on null', () => {
+    const result = validateRulebookExtract(null);
+    expect(result.passed).toBe(false);
+    expect(result.errors[0]).toContain('non-null object');
+  });
+
+  test('fails on missing objective', () => {
+    const ext = validExtract();
+    delete ext.objective;
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('objective'))).toBe(true);
+  });
+
+  test('fails on empty components', () => {
+    const ext = validExtract();
+    ext.components = [];
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('components'))).toBe(true);
+  });
+
+  test('fails on component without name', () => {
+    const ext = validExtract();
+    ext.components = [{ quantity: 5 }];
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('components[0].name'))).toBe(true);
+  });
+
+  test('fails on empty setup', () => {
+    const ext = validExtract();
+    ext.setup = [];
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('setup'))).toBe(true);
+  });
+
+  test('fails on setup with empty string', () => {
+    const ext = validExtract();
+    ext.setup = ['Good step', ''];
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('setup[1]'))).toBe(true);
+  });
+
+  test('fails on missing turnStructure', () => {
+    const ext = validExtract();
+    delete ext.turnStructure;
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('turnStructure'))).toBe(true);
+  });
+
+  test('fails on empty turnStructure.phases', () => {
+    const ext = validExtract();
+    ext.turnStructure.phases = [];
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('turnStructure.phases'))).toBe(true);
+  });
+
+  test('fails on missing coreMechanic', () => {
+    const ext = validExtract();
+    delete ext.coreMechanic;
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('coreMechanic'))).toBe(true);
+  });
+
+  test('fails on missing scoring', () => {
+    const ext = validExtract();
+    delete ext.scoring;
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('scoring'))).toBe(true);
+  });
+
+  test('fails on missing scoring.winCondition', () => {
+    const ext = validExtract();
+    ext.scoring = { description: 'Count.' };
+    const result = validateRulebookExtract(ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('winCondition'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSourceContract (combined + identity)
+// ---------------------------------------------------------------------------
+describe('validateSourceContract', () => {
+  test('passes with valid metadata + extract', () => {
+    const result = validateSourceContract(validMetadata(), validExtract());
+    expect(result.passed).toBe(true);
+  });
+
+  test('combines errors from both metadata and extract', () => {
+    const meta = validMetadata();
+    delete meta.slug;
+    const ext = validExtract();
+    delete ext.objective;
+    const result = validateSourceContract(meta, ext);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('slug'))).toBe(true);
+    expect(result.errors.some((e) => e.includes('objective'))).toBe(true);
+  });
+
+  test('detects identity mismatch: slug', () => {
+    const meta = validMetadata();
+    const registry = { slug: 'different-slug', gameName: 'Test Game' };
+    const result = validateSourceContract(meta, validExtract(), registry);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('Identity mismatch') && e.includes('slug'))).toBe(true);
+  });
+
+  test('detects identity mismatch: gameName', () => {
+    const meta = validMetadata();
+    const registry = { slug: 'test-game', gameName: 'Different Name' };
+    const result = validateSourceContract(meta, validExtract(), registry);
+    expect(result.passed).toBe(false);
+    expect(result.errors.some((e) => e.includes('Identity mismatch') && e.includes('gameName'))).toBe(true);
+  });
+
+  test('passes identity check when registry matches', () => {
+    const meta = validMetadata();
+    const registry = { slug: 'test-game', gameName: 'Test Game' };
+    const result = validateSourceContract(meta, validExtract(), registry);
+    expect(result.passed).toBe(true);
+  });
+
+  test('passes without registry entry (no identity check)', () => {
+    const result = validateSourceContract(validMetadata(), validExtract(), null);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI tests
+// ---------------------------------------------------------------------------
+describe('validate-real-input-source-contract CLI', () => {
+  function runCLI(args) {
+    try {
+      const result = execFileSync('node', [CLI_SCRIPT, ...args], {
+        encoding: 'utf8',
+        stdio: 'pipe',
+        timeout: 10000,
+        cwd: path.resolve(__dirname, '../..'),
+      });
+      return { exitCode: 0, stdout: result, stderr: '' };
+    } catch (err) {
+      return { exitCode: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+    }
+  }
+
+  test('exits 2 with no arguments', () => {
+    const { exitCode, stderr } = runCLI([]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Usage');
+  });
+
+  test('exits 2 for unknown fixture slug', () => {
+    const { exitCode, stderr } = runCLI(['--fixture', 'nonexistent']);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Unknown fixture slug');
+  });
+
+  test('exits 0 for --all with valid fixtures', () => {
+    const { exitCode, stdout } = runCLI(['--all']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('ALL PASSED');
+  });
+
+  test('exits 0 for --fixture sakura-market', () => {
+    const { exitCode, stdout } = runCLI(['--fixture', 'sakura-market']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('PASSED');
+  });
+
+  test('exits 0 for --fixture stellar-drift', () => {
+    const { exitCode, stdout } = runCLI(['--fixture', 'stellar-drift']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('PASSED');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable source contract validator that validates real-input fixture metadata and rulebook-extract files before normalization. Catches structural issues early, before the CLI or E2E smoke attempts rendering.

## Changes

- **`scripts/validate-real-input-source-contract.cjs`** — Source contract validator with `validateMetadata`, `validateRulebookExtract`, `validateSourceContract` functions + standalone CLI (`--all` or `--fixture <slug>`)
- **`tests/scripts/validateRealInputSourceContract.test.js`** — 34 unit tests covering valid/invalid cases, identity mismatches, CLI error handling
- **`scripts/run-real-input-preview.mjs`** — Validates source contracts before normalization; exits 1 on failure
- **`tests/e2e/tutorial_full_flow_smoke.test.js`** — Validates source contracts in `beforeAll` before each fixture is normalized/rendered
- **`tests/fixtures/tutorial-real-input/README.md`** — Source contract rules documentation

## Validation rules

### Metadata
- `slug`: non-empty string
- `title`: non-empty string
- `playerCount`: object with positive `min` <= `max`
- `designers`: non-empty array of non-empty strings
- `playtimeMinutes`: optional; if present, non-negative `min` and `max`

### Rulebook-extract
- `objective`: non-empty string
- `components`: non-empty array with objects having `name`
- `setup`: non-empty array of non-empty strings
- `turnStructure`: object with `phases` (non-empty array) and `description`
- `coreMechanic`: object with `name` and `description`
- `scoring`: object with `winCondition`

### Identity consistency
- `metadata.slug` matches registry `slug`
- `metadata.title` matches registry `gameName`

## What stays unchanged

- Normalizer logic
- Artifact validator logic
- Registry and coverage report helpers
- E2E smoke fixture matrix behavior
- CLI smoke (Ubuntu/Windows) and macOS graceful skip
- Golden baselines and workflow triggers
- Renderer logic

## Testing

- 34 source contract unit tests pass
- Full local suite: 53 suites, 610 tests (609 passed, 1 skipped)
- Source validation CLI: `node scripts/validate-real-input-source-contract.cjs --all` passes both fixtures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation step for real-input fixtures before normalization, with clear error reporting and fail-fast behavior.
  * Introduced a command-line validator to check all fixtures or a single fixture by slug.

* **Bug Fixes**
  * Prevents invalid source files from progressing through the preview and smoke-test flow.
  * Adds consistency checks between fixture metadata and registry details.

* **Documentation**
  * Updated the fixture README with the new validation workflow and required source file structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->