### PR TITLE
feat: ad-hoc offline real-input preview mode v1

### DIFF
--- a/scripts/run-real-input-preview.mjs
+++ b/scripts/run-real-input-preview.mjs
@@ -1,25 +1,29 @@
 #!/usr/bin/env node
 
 /**
- * run-real-input-preview.mjs — Offline CLI for running a registered real-input
- * fixture through the full tutorial preview pipeline.
+ * run-real-input-preview.mjs — Offline CLI for running a real-input fixture
+ * through the full tutorial preview pipeline.
  *
- * Usage:
- *   node scripts/run-real-input-preview.mjs --fixture <slug> --out <output-dir>
+ * Modes:
+ *   Registered fixture:
+ *     node scripts/run-real-input-preview.mjs --fixture <slug> --out <output-dir>
+ *
+ *   Ad-hoc local source:
+ *     node scripts/run-real-input-preview.mjs --metadata <path> --rulebook-extract <path> --expected <path> --out <output-dir>
  *
  * Pipeline:
- *   registry lookup → normalize → generate → render → ffprobe → validate → coverage report
+ *   source validation → normalize → generate → render → ffprobe → validate → coverage report
  *
  * Exit codes:
  *   0 = success (all steps pass)
  *   1 = pipeline or validation failure
- *   2 = invalid arguments or missing fixture
+ *   2 = invalid arguments or missing fixture/files
  */
 
 import { createRequire } from 'node:module';
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve, join, dirname } from 'node:path';
+import { resolve, join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -43,15 +47,59 @@ function getArg(name) {
 }
 
 const fixtureSlug = getArg('fixture');
+const metadataPath = getArg('metadata');
+const rulebookExtractPath = getArg('rulebook-extract');
+const expectedPath = getArg('expected');
 const outDir = getArg('out');
 
-if (!fixtureSlug || !outDir) {
-  console.error('Usage: node scripts/run-real-input-preview.mjs --fixture <slug> --out <output-dir>');
+// ---------------------------------------------------------------------------
+// Mode detection and validation
+// ---------------------------------------------------------------------------
+const isRegisteredMode = !!fixtureSlug;
+const isAdHocMode = !!(metadataPath || rulebookExtractPath || expectedPath);
+
+if (isRegisteredMode && isAdHocMode) {
+  console.error('[preview-cli] ERROR: Cannot mix --fixture with --metadata/--rulebook-extract/--expected.');
+  console.error('[preview-cli] Use either registered mode (--fixture) or ad-hoc mode (--metadata + --rulebook-extract + --expected).');
+  process.exit(2);
+}
+
+if (!isRegisteredMode && !isAdHocMode) {
+  console.error('Usage:');
+  console.error('');
+  console.error('  Registered fixture mode:');
+  console.error('    node scripts/run-real-input-preview.mjs --fixture <slug> --out <output-dir>');
+  console.error('');
+  console.error('  Ad-hoc local source mode:');
+  console.error('    node scripts/run-real-input-preview.mjs --metadata <path> --rulebook-extract <path> --expected <path> --out <output-dir>');
   console.error('');
   console.error('Options:');
-  console.error('  --fixture  Slug of a registered real-input fixture (e.g., sakura-market)');
-  console.error('  --out      Output directory for preview artifacts');
+  console.error('  --fixture          Slug of a registered real-input fixture (e.g., sakura-market)');
+  console.error('  --metadata         Path to metadata JSON (ad-hoc mode)');
+  console.error('  --rulebook-extract Path to rulebook-extract JSON (ad-hoc mode)');
+  console.error('  --expected         Path to expected contract JSON (ad-hoc mode)');
+  console.error('  --out              Output directory for preview artifacts');
   process.exit(2);
+}
+
+if (!outDir) {
+  console.error('[preview-cli] ERROR: --out <output-dir> is required.');
+  process.exit(2);
+}
+
+if (isAdHocMode) {
+  if (!metadataPath) {
+    console.error('[preview-cli] ERROR: --metadata is required in ad-hoc mode.');
+    process.exit(2);
+  }
+  if (!rulebookExtractPath) {
+    console.error('[preview-cli] ERROR: --rulebook-extract is required in ad-hoc mode.');
+    process.exit(2);
+  }
+  if (!expectedPath) {
+    console.error('[preview-cli] ERROR: --expected is required in ad-hoc mode.');
+    process.exit(2);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -67,52 +115,113 @@ const RENDER_SCRIPT = resolve(PROJECT_ROOT, 'scripts/render-storyboard-ffmpeg.mj
 const resolvedOut = resolve(outDir);
 
 // ---------------------------------------------------------------------------
-// Step 1: Load registry and find fixture
+// Resolve source paths based on mode
 // ---------------------------------------------------------------------------
-console.log(`[preview-cli] Loading registry: ${REGISTRY_PATH}`);
-let registry;
-try {
-  registry = loadRegistry(REGISTRY_PATH);
-} catch (err) {
-  console.error(`[preview-cli] Failed to load registry: ${err.message}`);
-  process.exit(2);
+let sourcePaths; // { metadata, extract, expected }
+let slug;
+let gameName;
+let profile;
+let sourceMode;
+let registryEntry; // for identity checks (null in ad-hoc mode)
+let metadataFile;
+let rulebookExtractFile;
+let expectedFile;
+
+if (isRegisteredMode) {
+  sourceMode = 'registered';
+
+  console.log(`[preview-cli] Mode: registered fixture`);
+  console.log(`[preview-cli] Loading registry: ${REGISTRY_PATH}`);
+  let registry;
+  try {
+    registry = loadRegistry(REGISTRY_PATH);
+  } catch (err) {
+    console.error(`[preview-cli] Failed to load registry: ${err.message}`);
+    process.exit(2);
+  }
+
+  const fixture = findFixtureBySlug(registry, fixtureSlug);
+  if (!fixture) {
+    console.error(`[preview-cli] Unknown fixture slug: "${fixtureSlug}"`);
+    console.error(`[preview-cli] Available slugs: ${registry.fixtures.map((f) => f.slug).join(', ')}`);
+    process.exit(2);
+  }
+
+  if (!fixture.enabled) {
+    console.error(`[preview-cli] Fixture "${fixtureSlug}" is disabled in the registry.`);
+    process.exit(2);
+  }
+
+  const fileCheck = validateFixtureFiles(fixture, REGISTRY_DIR);
+  if (!fileCheck.valid) {
+    console.error(`[preview-cli] Missing fixture files: ${fileCheck.missing.join(', ')}`);
+    process.exit(2);
+  }
+
+  sourcePaths = resolveFixturePaths(fixture, REGISTRY_DIR);
+  slug = fixture.slug;
+  gameName = fixture.gameName;
+  profile = fixture.profile;
+  registryEntry = fixture;
+  metadataFile = fixture.metadataFile;
+  rulebookExtractFile = fixture.rulebookExtractFile;
+  expectedFile = fixture.expectedFile;
+} else {
+  sourceMode = 'ad-hoc';
+
+  console.log(`[preview-cli] Mode: ad-hoc local source`);
+
+  const resolvedMetadata = resolve(metadataPath);
+  const resolvedExtract = resolve(rulebookExtractPath);
+  const resolvedExpected = resolve(expectedPath);
+
+  // Verify files exist
+  if (!existsSync(resolvedMetadata)) {
+    console.error(`[preview-cli] Metadata file not found: ${resolvedMetadata}`);
+    process.exit(2);
+  }
+  if (!existsSync(resolvedExtract)) {
+    console.error(`[preview-cli] Rulebook-extract file not found: ${resolvedExtract}`);
+    process.exit(2);
+  }
+  if (!existsSync(resolvedExpected)) {
+    console.error(`[preview-cli] Expected contract file not found: ${resolvedExpected}`);
+    process.exit(2);
+  }
+
+  sourcePaths = { metadata: resolvedMetadata, extract: resolvedExtract, expected: resolvedExpected };
+  registryEntry = null;
+  metadataFile = basename(resolvedMetadata);
+  rulebookExtractFile = basename(resolvedExtract);
+  expectedFile = basename(resolvedExpected);
+
+  // Derive slug and gameName from metadata
+  let metaPreview;
+  try {
+    metaPreview = JSON.parse(readFileSync(resolvedMetadata, 'utf8'));
+  } catch (err) {
+    console.error(`[preview-cli] Failed to parse metadata JSON: ${err.message}`);
+    process.exit(2);
+  }
+  slug = metaPreview.slug || 'ad-hoc-preview';
+  gameName = metaPreview.title || 'Ad-Hoc Preview';
+  profile = 'ad-hoc local source';
 }
 
-const fixture = findFixtureBySlug(registry, fixtureSlug);
-if (!fixture) {
-  console.error(`[preview-cli] Unknown fixture slug: "${fixtureSlug}"`);
-  console.error(`[preview-cli] Available slugs: ${registry.fixtures.map((f) => f.slug).join(', ')}`);
-  process.exit(2);
-}
-
-if (!fixture.enabled) {
-  console.error(`[preview-cli] Fixture "${fixtureSlug}" is disabled in the registry.`);
-  process.exit(2);
-}
-
-// ---------------------------------------------------------------------------
-// Step 2: Validate fixture files exist
-// ---------------------------------------------------------------------------
-const fileCheck = validateFixtureFiles(fixture, REGISTRY_DIR);
-if (!fileCheck.valid) {
-  console.error(`[preview-cli] Missing fixture files: ${fileCheck.missing.join(', ')}`);
-  process.exit(2);
-}
-
-const paths = resolveFixturePaths(fixture, REGISTRY_DIR);
-console.log(`[preview-cli] Fixture: ${fixture.slug} (${fixture.gameName})`);
-console.log(`[preview-cli] Metadata: ${paths.metadata}`);
-console.log(`[preview-cli] Extract: ${paths.extract}`);
-console.log(`[preview-cli] Expected: ${paths.expected}`);
+console.log(`[preview-cli] Fixture: ${slug} (${gameName})`);
+console.log(`[preview-cli] Metadata: ${sourcePaths.metadata}`);
+console.log(`[preview-cli] Extract: ${sourcePaths.extract}`);
+console.log(`[preview-cli] Expected: ${sourcePaths.expected}`);
 console.log(`[preview-cli] Output: ${resolvedOut}`);
+console.log(`[preview-cli] Source mode: ${sourceMode}`);
 
 // ---------------------------------------------------------------------------
-// Step 2b: Validate source contracts before normalization
+// Source contract validation
 // ---------------------------------------------------------------------------
 console.log('[preview-cli] Validating source contracts...');
-const metadataJson = JSON.parse(readFileSync(paths.metadata, 'utf8'));
-const extractJson = JSON.parse(readFileSync(paths.extract, 'utf8'));
-const sourceResult = validateSourceContract(metadataJson, extractJson, fixture);
+const metadataJson = JSON.parse(readFileSync(sourcePaths.metadata, 'utf8'));
+const extractJson = JSON.parse(readFileSync(sourcePaths.extract, 'utf8'));
+const sourceResult = validateSourceContract(metadataJson, extractJson, registryEntry);
 if (!sourceResult.passed) {
   console.error(`[preview-cli] Source contract validation FAILED (${sourceResult.errors.length} error(s)):`);
   sourceResult.errors.forEach((e) => console.error(`  - ${e}`));
@@ -121,20 +230,20 @@ if (!sourceResult.passed) {
 console.log('[preview-cli]   → Source contracts valid');
 
 // ---------------------------------------------------------------------------
-// Step 3: Create output directory
+// Create output directory
 // ---------------------------------------------------------------------------
 mkdirSync(resolvedOut, { recursive: true });
 
 // ---------------------------------------------------------------------------
-// Step 4: Normalize
+// Normalize
 // ---------------------------------------------------------------------------
-const normalizedPath = join(resolvedOut, `${fixture.slug}-normalized.json`);
+const normalizedPath = join(resolvedOut, `${slug}-normalized.json`);
 console.log('[preview-cli] Step 1/6: Normalizing fixture...');
 try {
   execFileSync('node', [
     NORMALIZER_SCRIPT,
-    '--metadata', paths.metadata,
-    '--extract', paths.extract,
+    '--metadata', sourcePaths.metadata,
+    '--extract', sourcePaths.extract,
     '--out', normalizedPath,
   ], { encoding: 'utf8', stdio: 'pipe', timeout: 15000, cwd: PROJECT_ROOT });
 } catch (err) {
@@ -144,14 +253,14 @@ try {
 console.log(`[preview-cli]   → ${normalizedPath}`);
 
 // ---------------------------------------------------------------------------
-// Step 5: Generate tutorial preview artifacts
+// Generate tutorial preview artifacts
 // ---------------------------------------------------------------------------
 console.log('[preview-cli] Step 2/6: Generating tutorial artifacts...');
 try {
   execFileSync('node', [
     GENERATE_SCRIPT,
     '--fixture', normalizedPath,
-    '--slug', fixture.slug,
+    '--slug', slug,
     '--out', resolvedOut,
   ], { encoding: 'utf8', stdio: 'pipe', timeout: 30000, cwd: PROJECT_ROOT });
 } catch (err) {
@@ -161,7 +270,7 @@ try {
 console.log('[preview-cli]   → script.json, storyboard.json, captions.srt, render-config.json, manifest.json');
 
 // ---------------------------------------------------------------------------
-// Step 6: Render MP4
+// Render MP4
 // ---------------------------------------------------------------------------
 const mp4Path = join(resolvedOut, 'preview.mp4');
 console.log('[preview-cli] Step 3/6: Rendering MP4...');
@@ -178,7 +287,7 @@ try {
 console.log(`[preview-cli]   → ${mp4Path}`);
 
 // ---------------------------------------------------------------------------
-// Step 7: Capture ffprobe.json
+// Capture ffprobe.json
 // ---------------------------------------------------------------------------
 const ffprobePath = join(resolvedOut, 'ffprobe.json');
 console.log('[preview-cli] Step 4/6: Capturing ffprobe metadata...');
@@ -197,10 +306,10 @@ try {
 console.log(`[preview-cli]   → ${ffprobePath}`);
 
 // ---------------------------------------------------------------------------
-// Step 8: Validate against contract
+// Validate against contract
 // ---------------------------------------------------------------------------
 console.log('[preview-cli] Step 5/6: Validating artifact contract...');
-const expectedContract = JSON.parse(readFileSync(paths.expected, 'utf8'));
+const expectedContract = JSON.parse(readFileSync(sourcePaths.expected, 'utf8'));
 const validationResult = validateRealInputArtifact(resolvedOut, expectedContract);
 
 const validationOutputPath = join(resolvedOut, 'validation-result.json');
@@ -214,7 +323,7 @@ if (validationResult.passed) {
 }
 
 // ---------------------------------------------------------------------------
-// Step 9: Write coverage report
+// Write coverage report
 // ---------------------------------------------------------------------------
 console.log('[preview-cli] Step 6/6: Writing coverage report...');
 const ffprobeData = existsSync(ffprobePath) ? JSON.parse(readFileSync(ffprobePath, 'utf8')) : null;
@@ -222,14 +331,14 @@ const manifestData = existsSync(join(resolvedOut, 'manifest.json'))
   ? JSON.parse(readFileSync(join(resolvedOut, 'manifest.json'), 'utf8'))
   : null;
 
-const report = createReport({ registryPath: REGISTRY_PATH, enabledCount: 1 });
+const report = createReport({ registryPath: sourceMode === 'registered' ? REGISTRY_PATH : '(ad-hoc)', enabledCount: 1 });
 const entry = buildFixtureEntry({
-  slug: fixture.slug,
-  gameName: fixture.gameName,
-  profile: fixture.profile,
-  metadataFile: fixture.metadataFile,
-  rulebookExtractFile: fixture.rulebookExtractFile,
-  expectedFile: fixture.expectedFile,
+  slug,
+  gameName,
+  profile,
+  metadataFile,
+  rulebookExtractFile,
+  expectedFile,
   normalizedFixturePath: normalizedPath,
   artifactDir: resolvedOut,
   ffprobeData,
@@ -237,6 +346,7 @@ const entry = buildFixtureEntry({
   requiredArtifacts: expectedContract.requiredArtifacts || [],
   contractValidation: validationResult,
 });
+entry.sourceMode = sourceMode;
 report.fixtures.push(entry);
 
 const coverageReportPath = join(resolvedOut, 'real-input-preview-coverage.json');
@@ -248,7 +358,7 @@ console.log(`[preview-cli]   → ${coverageReportPath}`);
 // ---------------------------------------------------------------------------
 console.log('');
 if (validationResult.passed) {
-  console.log(`[preview-cli] SUCCESS: ${fixture.slug} preview pipeline completed.`);
+  console.log(`[preview-cli] SUCCESS: ${slug} preview pipeline completed (${sourceMode} mode).`);
   console.log(`[preview-cli] Output directory: ${resolvedOut}`);
   process.exit(0);
 } else {

--- a/tests/fixtures/tutorial-real-input/README.md
+++ b/tests/fixtures/tutorial-real-input/README.md
@@ -271,6 +271,33 @@ node scripts/run-real-input-preview.mjs --fixture sakura-market --out out/real-i
 node scripts/run-real-input-preview.mjs --fixture stellar-drift --out out/real-input-previews/stellar-drift
 ```
 
+### Ad-hoc local source mode
+
+Run a preview from local metadata, rulebook-extract, and expected contract files
+without registering in `fixtures.json`:
+
+```bash
+node scripts/run-real-input-preview.mjs \
+  --metadata /path/to/my-game.metadata.json \
+  --rulebook-extract /path/to/my-game.rulebook-extract.json \
+  --expected /path/to/my-game.expected.json \
+  --out out/real-input-previews/my-game
+```
+
+Ad-hoc mode:
+- Derives slug and game name from `metadata.slug` and `metadata.title`
+- Validates source contracts without registry identity checks
+- Runs the same pipeline as registered mode (normalize → generate → render → ffprobe → validate → coverage report)
+- Marks the coverage report entry with `sourceMode: "ad-hoc"`
+- Does not mutate `fixtures.json`
+
+### Mode exclusivity
+
+The CLI enforces mutual exclusivity between modes:
+- `--fixture` cannot be combined with `--metadata`, `--rulebook-extract`, or `--expected`
+- Ad-hoc mode requires all three source paths: `--metadata`, `--rulebook-extract`, `--expected`
+- Both modes require `--out`
+
 ### Requirements
 
 - Node.js 20+

--- a/tests/scripts/runRealInputPreview.test.js
+++ b/tests/scripts/runRealInputPreview.test.js
@@ -155,7 +155,7 @@ describe('run-real-input-preview CLI — argument errors', () => {
   test('exits 2 with --fixture but no --out', () => {
     const { exitCode, stderr } = runCLI(['--fixture', 'sakura-market']);
     expect(exitCode).toBe(2);
-    expect(stderr).toContain('Usage');
+    expect(stderr).toContain('--out');
   });
 
   test('exits 2 with --out but no --fixture', () => {
@@ -175,5 +175,139 @@ describe('run-real-input-preview CLI — argument errors', () => {
     const { stderr } = runCLI(['--fixture', 'bad-slug', '--out', '/tmp/test-out']);
     expect(stderr).toContain('sakura-market');
     expect(stderr).toContain('stellar-drift');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ad-hoc mode argument handling tests (no FFmpeg required)
+// ---------------------------------------------------------------------------
+describe('run-real-input-preview CLI — ad-hoc mode arguments', () => {
+  function runCLI(args) {
+    try {
+      const result = execFileSync('node', [CLI_SCRIPT, ...args], {
+        encoding: 'utf8',
+        stdio: 'pipe',
+        timeout: 10000,
+        cwd: path.resolve(__dirname, '../..'),
+      });
+      return { exitCode: 0, stdout: result, stderr: '' };
+    } catch (err) {
+      return { exitCode: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+    }
+  }
+
+  const VALID_METADATA = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.metadata.json');
+  const VALID_EXTRACT = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.rulebook-extract.json');
+  const VALID_EXPECTED = path.resolve(__dirname, '../fixtures/tutorial-real-input/sakura-market.expected.json');
+
+  test('exits 2 when mixing --fixture with --metadata', () => {
+    const { exitCode, stderr } = runCLI([
+      '--fixture', 'sakura-market',
+      '--metadata', VALID_METADATA,
+      '--out', '/tmp/test-out',
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Cannot mix');
+  });
+
+  test('exits 2 when mixing --fixture with --rulebook-extract', () => {
+    const { exitCode, stderr } = runCLI([
+      '--fixture', 'sakura-market',
+      '--rulebook-extract', VALID_EXTRACT,
+      '--out', '/tmp/test-out',
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Cannot mix');
+  });
+
+  test('exits 2 when --metadata is provided but --rulebook-extract is missing', () => {
+    const { exitCode, stderr } = runCLI([
+      '--metadata', VALID_METADATA,
+      '--expected', VALID_EXPECTED,
+      '--out', '/tmp/test-out',
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('--rulebook-extract');
+  });
+
+  test('exits 2 when --metadata is provided but --expected is missing', () => {
+    const { exitCode, stderr } = runCLI([
+      '--metadata', VALID_METADATA,
+      '--rulebook-extract', VALID_EXTRACT,
+      '--out', '/tmp/test-out',
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('--expected');
+  });
+
+  test('exits 2 when ad-hoc mode but --out is missing', () => {
+    const { exitCode, stderr } = runCLI([
+      '--metadata', VALID_METADATA,
+      '--rulebook-extract', VALID_EXTRACT,
+      '--expected', VALID_EXPECTED,
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('--out');
+  });
+
+  test('exits 2 when metadata file does not exist', () => {
+    const { exitCode, stderr } = runCLI([
+      '--metadata', '/nonexistent/meta.json',
+      '--rulebook-extract', VALID_EXTRACT,
+      '--expected', VALID_EXPECTED,
+      '--out', '/tmp/test-out',
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('not found');
+  });
+
+  test('exits 2 when rulebook-extract file does not exist', () => {
+    const { exitCode, stderr } = runCLI([
+      '--metadata', VALID_METADATA,
+      '--rulebook-extract', '/nonexistent/extract.json',
+      '--expected', VALID_EXPECTED,
+      '--out', '/tmp/test-out',
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('not found');
+  });
+
+  test('exits 2 when expected contract file does not exist', () => {
+    const { exitCode, stderr } = runCLI([
+      '--metadata', VALID_METADATA,
+      '--rulebook-extract', VALID_EXTRACT,
+      '--expected', '/nonexistent/expected.json',
+      '--out', '/tmp/test-out',
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('not found');
+  });
+
+  test('exits 1 when metadata has invalid source contract', () => {
+    // Create a temp metadata file with missing required fields
+    const tmpMeta = path.join(os.tmpdir(), 'bad-meta-adhoc.json');
+    fs.writeFileSync(tmpMeta, JSON.stringify({ slug: 'test' }), 'utf8'); // missing title, playerCount, designers
+    try {
+      const { exitCode, stderr } = runCLI([
+        '--metadata', tmpMeta,
+        '--rulebook-extract', VALID_EXTRACT,
+        '--expected', VALID_EXPECTED,
+        '--out', path.join(os.tmpdir(), 'adhoc-test-out'),
+      ]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain('Source contract validation FAILED');
+    } finally {
+      try { fs.unlinkSync(tmpMeta); } catch {}
+      try { fs.rmSync(path.join(os.tmpdir(), 'adhoc-test-out'), { recursive: true, force: true }); } catch {}
+    }
+  });
+
+  test('usage message shows both registered and ad-hoc modes', () => {
+    const { stderr } = runCLI([]);
+    expect(stderr).toContain('Registered fixture mode');
+    expect(stderr).toContain('Ad-hoc local source mode');
+    expect(stderr).toContain('--metadata');
+    expect(stderr).toContain('--rulebook-extract');
+    expect(stderr).toContain('--expected');
   });
 });


### PR DESCRIPTION
## Summary

Extends the offline real-input preview CLI with an ad-hoc local-source mode. Operators can now run a preview from local metadata, rulebook-extract, and expected contract files without editing the fixture registry.

## Changes

- **`scripts/run-real-input-preview.mjs`** — Dual mode support:
  - Registered mode: `--fixture <slug> --out <dir>` (unchanged behavior)
  - Ad-hoc mode: `--metadata <path> --rulebook-extract <path> --expected <path> --out <dir>`
- **`tests/scripts/runRealInputPreview.test.js`** — 10 new ad-hoc mode tests (28 total)
- **`tests/fixtures/tutorial-real-input/README.md`** — Ad-hoc mode docs, mode exclusivity rules

## Ad-hoc mode behavior

- Derives slug/gameName from `metadata.slug` and `metadata.title`
- Validates source contracts without registry identity checks
- Runs the same pipeline as registered mode
- Marks coverage report entries with `sourceMode: "ad-hoc"`
- Does not mutate `fixtures.json`

## Mode exclusivity

- `--fixture` cannot be combined with `--metadata`/`--rulebook-extract`/`--expected`
- Ad-hoc mode requires all three source paths
- Both modes require `--out`

## What stays unchanged

- Registered fixture mode behavior
- E2E smoke (registry-driven two-fixture matrix)
- CI CLI smoke (sakura-market on Ubuntu/Windows)
- Source contract validator
- Normalizer, artifact validator, coverage report
- Golden baselines and workflow triggers

## Testing

- 28 CLI/registry unit tests pass (18 existing + 10 new ad-hoc)
- Full local suite: 53 suites, 620 tests (619 passed, 1 skipped)
- Existing registered mode CLI tests unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview runs now support both registered fixtures and ad-hoc local inputs.
  * Added clearer mode-specific usage help and validation messages.
  * Generated reports now indicate whether a run used registered or ad-hoc sources.

* **Bug Fixes**
  * Improved handling for missing required inputs and invalid argument combinations.
  * Better path validation and metadata checks before preview generation.

* **Documentation**
  * Expanded the preview guide with ad-hoc run instructions and mode exclusivity rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->