### PR TITLE
feat: add bounded ad-hoc real-input CLI smoke in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,41 @@ jobs:
           echo "All CLI smoke output files verified."
         shell: bash
 
+      - name: Ad-hoc CLI smoke (sakura-market via explicit paths)
+        run: |
+          # Skip if drawtext filter is not available (e.g. macOS brew ffmpeg)
+          if ! ffmpeg -hide_banner -loglevel error -f lavfi -i color=c=black:s=64x64:d=0.1 -vf drawtext=text=X:fontsize=12 -frames:v 1 -f null - 2>/dev/null; then
+            echo "[adhoc-cli-smoke] SKIPPED: drawtext filter not available on this runner."
+            exit 0
+          fi
+          node scripts/run-real-input-preview.mjs \
+            --metadata tests/fixtures/tutorial-real-input/sakura-market.metadata.json \
+            --rulebook-extract tests/fixtures/tutorial-real-input/sakura-market.rulebook-extract.json \
+            --expected tests/fixtures/tutorial-real-input/sakura-market.expected.json \
+            --out out/real-input-adhoc-cli-smoke/sakura-market
+        shell: bash
+
+      - name: Verify ad-hoc CLI smoke output
+        run: |
+          # Skip verification if ad-hoc CLI smoke was skipped (no drawtext)
+          if [ ! -d out/real-input-adhoc-cli-smoke/sakura-market ]; then
+            echo "[adhoc-cli-smoke] SKIPPED: output directory not present (drawtext likely unavailable)."
+            exit 0
+          fi
+          echo "--- Verifying ad-hoc CLI smoke output ---"
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/sakura-market-normalized.json
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/script.json
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/storyboard.json
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/captions.srt
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/render-config.json
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/manifest.json
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/preview.mp4
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/ffprobe.json
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/validation-result.json
+          test -f out/real-input-adhoc-cli-smoke/sakura-market/real-input-preview-coverage.json
+          echo "All ad-hoc CLI smoke output files verified."
+        shell: bash
+
       - name: Render preview
         run: |
           mkdir -p out artifacts
@@ -415,6 +450,15 @@ jobs:
         with:
           name: real-input-cli-smoke-${{ matrix.os }}
           path: out/real-input-cli-smoke/**
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload ad-hoc CLI smoke output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-input-adhoc-cli-smoke-${{ matrix.os }}
+          path: out/real-input-adhoc-cli-smoke/**
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ Thumbs.db
 # Generated CI artifacts (not committed)
 artifacts/real-input-smoke-coverage.json
 out/real-input-cli-smoke/
+out/real-input-adhoc-cli-smoke/

--- a/tests/fixtures/tutorial-real-input/README.md
+++ b/tests/fixtures/tutorial-real-input/README.md
@@ -441,3 +441,27 @@ The CLI smoke uses `sakura-market` (the original stable real-input sample) to
 keep CI runtime bounded. The full two-fixture matrix is already exercised by the
 E2E smoke test in the same job. The CLI smoke specifically proves the operator
 CLI path — not fixture coverage breadth.
+
+### Ad-hoc CLI smoke
+
+CI also exercises the ad-hoc local-source mode using explicit file paths (not
+`--fixture` registry lookup):
+
+```
+node scripts/run-real-input-preview.mjs \
+  --metadata tests/fixtures/tutorial-real-input/sakura-market.metadata.json \
+  --rulebook-extract tests/fixtures/tutorial-real-input/sakura-market.rulebook-extract.json \
+  --expected tests/fixtures/tutorial-real-input/sakura-market.expected.json \
+  --out out/real-input-adhoc-cli-smoke/sakura-market
+```
+
+This proves the ad-hoc mode pipeline works end-to-end in CI without depending
+on the fixture registry. Artifacts are uploaded as:
+
+| OS | Artifact name |
+|----|---------------|
+| ubuntu-latest | `real-input-adhoc-cli-smoke-ubuntu-latest` |
+| windows-latest | `real-input-adhoc-cli-smoke-windows-latest` |
+| macos-latest | Skipped (no drawtext) |
+
+The ad-hoc smoke uses the same `drawtext` guard as the registered CLI smoke.


### PR DESCRIPTION
## Summary

Adds a bounded CI smoke that exercises the ad-hoc local-source mode of `run-real-input-preview.mjs` end-to-end with FFmpeg. Proves the ad-hoc pipeline works in CI without relying on the fixture registry `--fixture` lookup.

## Changes

- **`.github/workflows/ci.yml`** — Adds 3 steps to `build-and-qa`:
  1. `Ad-hoc CLI smoke (sakura-market via explicit paths)` — runs CLI with `--metadata`, `--rulebook-extract`, `--expected`, `--out`
  2. `Verify ad-hoc CLI smoke output` — asserts all 10 expected output files exist
  3. `Upload ad-hoc CLI smoke output` — uploads as `real-input-adhoc-cli-smoke-${{ matrix.os }}`
- **`.gitignore`** — Adds `out/real-input-adhoc-cli-smoke/`
- **`tests/fixtures/tutorial-real-input/README.md`** — Documents ad-hoc CI smoke, artifact names, drawtext skip

## CI ad-hoc smoke command

```bash
node scripts/run-real-input-preview.mjs \
  --metadata tests/fixtures/tutorial-real-input/sakura-market.metadata.json \
  --rulebook-extract tests/fixtures/tutorial-real-input/sakura-market.rulebook-extract.json \
  --expected tests/fixtures/tutorial-real-input/sakura-market.expected.json \
  --out out/real-input-adhoc-cli-smoke/sakura-market
```

## Artifact details

| OS | Artifact name | Notes |
|----|---------------|-------|
| ubuntu-latest | `real-input-adhoc-cli-smoke-ubuntu-latest` | Full preview package |
| windows-latest | `real-input-adhoc-cli-smoke-windows-latest` | Full preview package |
| macos-latest | — | Skipped (no drawtext) |

## What stays unchanged

- Registered CLI smoke (sakura-market via --fixture)
- E2E two-fixture registry smoke (Jest-driven)
- Real-input smoke coverage artifact publishing
- Deterministic gem-collectors smoke
- Ad-hoc mode CLI logic (already merged in PR #453)
- Golden baselines and workflow triggers

## Testing

- Full local suite: 53 suites, 620 tests (619 passed, 1 skipped)
- Ad-hoc smoke exercised in CI (requires FFmpeg + drawtext)
- Same drawtext guard pattern as registered CLI smoke
